### PR TITLE
Fixed issues with invalid cell layout

### DIFF
--- a/XLForm/XL/Controllers/XLFormViewController.m
+++ b/XLForm/XL/Controllers/XLFormViewController.m
@@ -459,6 +459,7 @@ NSString * const kDeleteButtonTag = @"DeleteButtonTag";
         [cell setValue:value forKeyPath:keyPath];
     }];
     [cell setNeedsUpdateConstraints];
+    [cell setNeedsLayout];
 }
 
 -(BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath


### PR DESCRIPTION
This small change fixes an issue with multi value section having invalid layout on iPad when a new row is added. 

Form table view cells use auto layout for laying out subviews, however the call after cell configuration used old 

```
setNeedsLayout
```

call to inform the cell that it should update its layout. This was changed to 

```
setNeedsUpdateConstraints
```

Example image how it looked before the fix: 

![screen shot 2014-04-22 at 5 51 04 pm](https://cloud.githubusercontent.com/assets/968513/2767884/46e25dfa-ca3d-11e3-8db8-1523ccb02a16.png)
