### PR TITLE
Hiding keyboard with tap outside input

### DIFF
--- a/XLForm/XL/Controllers/XLFormViewController.m
+++ b/XLForm/XL/Controllers/XLFormViewController.m
@@ -129,6 +129,11 @@ NSString * const kDeleteButtonTag = @"DeleteButtonTag";
     tv.delegate = self;
     self.view = tv;
     self.tableView = tv;
+    
+    UITapGestureRecognizer *tableTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(hideKeyboard)];
+    [self.tableView addGestureRecognizer:tableTap];
+    UITapGestureRecognizer *navTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(hideKeyboard)];
+    [self.navigationController.navigationBar addGestureRecognizer:navTap];
 }
 
 - (void)viewDidLoad
@@ -309,6 +314,10 @@ NSString * const kDeleteButtonTag = @"DeleteButtonTag";
 
 -(void)showServerErrorMessage:(NSError *)error
 {
+}
+
+- (void)hideKeyboard {
+    [self.tableView endEditing:YES];
 }
 
 #pragma mark - Properties


### PR DESCRIPTION
Hides the keyboard when the user taps on the UINavigationBar or elsewhere in the table other than the input (if it does not have its own tap behavior).
