### PR TITLE
fix bug where textview has first responder

### DIFF
--- a/XLForm/XL/Controllers/XLFormViewController.m
+++ b/XLForm/XL/Controllers/XLFormViewController.m
@@ -415,6 +415,7 @@ NSString * const kDeleteButtonTag = @"DeleteButtonTag";
 
 -(void)showActivityIndicator
 {
+    [self.tableView endEditing:YES];
     self.progressView.mode = MRProgressOverlayViewModeIndeterminate;
     [self.progressView show:YES];
 }


### PR DESCRIPTION
Fixes issue where indicator is showing while another control is still first responder.

![ios simulator screen shot 8 may 2014 17 43 51](https://cloud.githubusercontent.com/assets/2887472/2918617/0e014356-d6d2-11e3-9ef0-623120e02dac.png)
