### PR TITLE
Extended XLFormSelectorCell to support non-primitive objects as option values

### DIFF
--- a/XLForm/XL/Cell/XLFormSelectorCell.m
+++ b/XLForm/XL/Cell/XLFormSelectorCell.m
@@ -122,15 +122,19 @@
     return self.rowDescriptor.selectorOptions;
 }
 
-
 -(BOOL)optionsViewControllerOptions:(id<XLSelectorTableViewControllerProtocol>)optionsViewController isOptionSelected:(id)option
 {
-    return [self.rowDescriptor.value isEqual:option];
+    return [self.rowDescriptor.value isEqual:option] || [self.rowDescriptor.value isEqual:[option formValue]];
 }
 
 - (void)optionsViewController:(XLFormOptionsViewController *)optionsViewController didSelectOption:(id)selectedValue atIndex:(NSIndexPath *)indexPath
 {
-    self.rowDescriptor.value = selectedValue;
+    if ([[selectedValue formValue] isKindOfClass:[NSString class]] || [[selectedValue formValue] isKindOfClass:[NSNumber class]]){
+        self.rowDescriptor.value = selectedValue;
+    }
+    else {
+        self.rowDescriptor.value = [selectedValue formValue];
+    }
     [self.formViewController.navigationController popViewControllerAnimated:YES];
 }
 


### PR DESCRIPTION
Here's some sample code to illustrate the change:

```
XLFormSectionDescriptor *section = [XLFormSectionDescriptor formSectionWithTitle:@"Dependent Info"];
[formDescriptor addFormSection:section];

row = [XLFormRowDescriptor formRowDescriptorWithTag:nil rowType:XLFormRowDescriptorTypeSelectorPush title:@"Relation to you"];
row.selectorOptions = @[[XLFormOptionsObject formOptionsObjectWithValue:[[CustomNameCodePair alloc] initWithName:@"Spouse" code:@"D0001"] displayText:@"Spouse"],
                        [XLFormOptionsObject formOptionsObjectWithValue:[[CustomNameCodePair alloc] initWithName:@"Parent" code:@"D0002"] displayText:@"Parent"],
                        [XLFormOptionsObject formOptionsObjectWithValue:[[CustomNameCodePair alloc] initWithName:@"Sibling" code:@"D0003"] displayText:@"Sibling"],
                        [XLFormOptionsObject formOptionsObjectWithValue:[[CustomNameCodePair alloc] initWithName:@"Child" code:@"D0004"] displayText:@"Child"]
                        ];
row.value = dependent.relation;     // CustomNameCodePair object
[section addFormRow:row];
```

Here's my CustomNameCodePair class implementation:

```
@implementation CustomNameCodePair

-(id) initWithName:(NSString *)name code:(NSString *)code {
    self = [super init];
    if (self) {
        self.name = name;
        self.code = code;
    }

    return self;
}

#pragma mark - hash and isEqual implementations

-(NSUInteger)hash {
    return self.code.hash;
}

-(BOOL)isEqual:(id)object {
    if (object == nil || ![object isKindOfClass:[CustomNameCodePair class]])
        return NO;

    return [self.code isEqual:((CustomNameCodePair *)object).code];
}

#pragma mark - toString() implementation

-(NSString *)displayText {
    return self.name;
}

@end
```
