### PR TITLE
Update Step Counter value on initial load

### DIFF
--- a/XLForm/XL/Cell/XLFormStepCounterCell.m
+++ b/XLForm/XL/Cell/XLFormStepCounterCell.m
@@ -74,6 +74,7 @@
     self.textLabel.text = self.rowDescriptor.title;
     self.textLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
     self.stepControl.value = [self.rowDescriptor.value doubleValue];
+    [self valueChanged:nil];
 }
  
 - (UIStepper *)stepControl


### PR DESCRIPTION
Step Counter fields were not showing their value on initial load. This didn't seem like optimal behavior, so it's just a matter of adding the `valueChanged` to `update`.
