### PR TITLE
Fixed default date not set in date picker

### DIFF
--- a/XLForm/XL/Cell/XLFormDateCell.m
+++ b/XLForm/XL/Cell/XLFormDateCell.m
@@ -44,6 +44,9 @@
 - (UIView *)inputView
 {
     if ([self.rowDescriptor.rowType isEqualToString:XLFormRowDescriptorTypeDate] || [self.rowDescriptor.rowType isEqualToString:XLFormRowDescriptorTypeTime] || [self.rowDescriptor.rowType isEqualToString:XLFormRowDescriptorTypeDateTime]){
+        if (self.rowDescriptor.value){
+            [self.datePicker setDate:self.rowDescriptor.value];
+        }
         return self.datePicker;
     }
     return [super inputView];


### PR DESCRIPTION
If you use the date picker (XLFormRowDescriptorTypeDate, ...) the `UIDatePicker` is not set with the value of the row descriptor.
