### PR TITLE
added decimalPad to input options

### DIFF
--- a/Examples/Inputs/InputsFormViewController.m
+++ b/Examples/Inputs/InputsFormViewController.m
@@ -32,6 +32,7 @@ NSString *const kEmail = @"email";
 NSString *const kTwitter = @"twitter";
 NSString *const kNumber = @"number";
 NSString *const kInteger = @"integer";
+NSString *const kDecimal = @"decimal";
 NSString *const kPassword = @"password";
 NSString *const kPhone = @"phone";
 NSString *const kUrl = @"url";
@@ -77,6 +78,10 @@ NSString *const kNotes = @"notes";
     
     // Integer
     row = [XLFormRowDescriptor formRowDescriptorWithTag:kInteger rowType:XLFormRowDescriptorTypeInteger title:@"Integer"];
+    [section addFormRow:row];
+	
+    // Decimal
+    row = [XLFormRowDescriptor formRowDescriptorWithTag:kDecimal rowType:XLFormRowDescriptorTypeDecimal title:@"Decimal"];
     [section addFormRow:row];
     
     // Password

--- a/README.md
+++ b/README.md
@@ -159,6 +159,11 @@ static NSString *const XLFormRowDescriptorTypeInteger = @"integer";
 Will be represented by a `UITextField` with `UIKeyboardTypeNumberPad`.
 
 ```objc
+static NSString *const XLFormRowDescriptorTypeDecimal = @"decimal";
+```
+Will be represented by a `UITextField` with `UIKeyboardTypeDecimalPad`.
+
+```objc
 static NSString *const XLFormRowDescriptorTypeTextView = @"textView";
 ```
 Will be represented by a `UITextView` with `UITextAutocorrectionTypeDefault`, `UITextAutocapitalizationTypeSentences` and `UIKeyboardTypeDefault`.

--- a/XLForm/XL/Cell/XLFormTextFieldCell.m
+++ b/XLForm/XL/Cell/XLFormTextFieldCell.m
@@ -100,6 +100,9 @@
     else if ([self.rowDescriptor.rowType isEqualToString:XLFormRowDescriptorTypeInteger]){
         self.textField.keyboardType = UIKeyboardTypeNumberPad;
     }
+    else if ([self.rowDescriptor.rowType isEqualToString:XLFormRowDescriptorTypeDecimal]){
+        self.textField.keyboardType = UIKeyboardTypeDecimalPad;
+    }
     else if ([self.rowDescriptor.rowType isEqualToString:XLFormRowDescriptorTypePassword]){
         self.textField.autocorrectionType = UITextAutocorrectionTypeNo;
         self.textField.autocapitalizationType = UITextAutocapitalizationTypeNone;

--- a/XLForm/XL/Controllers/XLFormViewController.m
+++ b/XLForm/XL/Controllers/XLFormViewController.m
@@ -154,6 +154,7 @@
                                                XLFormRowDescriptorTypePassword: [XLFormTextFieldCell class],
                                                XLFormRowDescriptorTypeNumber: [XLFormTextFieldCell class],
                                                XLFormRowDescriptorTypeInteger: [XLFormTextFieldCell class],
+                                               XLFormRowDescriptorTypeDecimal: [XLFormTextFieldCell class],
                                                XLFormRowDescriptorTypeSelectorPush: [XLFormSelectorCell class],
 											   XLFormRowDescriptorTypeSelectorPopover: [XLFormSelectorCell class],
                                                XLFormRowDescriptorTypeSelectorActionSheet: [XLFormSelectorCell class],

--- a/XLForm/XL/XLForm.h
+++ b/XLForm/XL/XLForm.h
@@ -76,6 +76,7 @@ static NSString *const XLFormRowDescriptorTypePhone = @"phone";
 static NSString *const XLFormRowDescriptorTypeTwitter = @"twitter";
 static NSString *const XLFormRowDescriptorTypeAccount = @"account";
 static NSString *const XLFormRowDescriptorTypeInteger = @"integer";
+static NSString *const XLFormRowDescriptorTypeDecimal = @"decimal";
 static NSString *const XLFormRowDescriptorTypeTextView = @"textView";
 static NSString *const XLFormRowDescriptorTypeSelectorPush = @"selectorPush";
 static NSString *const XLFormRowDescriptorTypeSelectorPopover = @"selectorPopover";


### PR DESCRIPTION
I'm missing the option for the iOS Decimal Keyboard. So here it is. 
