### PR TITLE
Fixed 'Expected a type' compiler error

### DIFF
--- a/XLForm/XL/Cell/XLFormDescriptorCell.h
+++ b/XLForm/XL/Cell/XLFormDescriptorCell.h
@@ -23,7 +23,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 
 @class XLFormRowDescriptor;


### PR DESCRIPTION
CGFloat is defined in the UIKit framework and therefore unknown in the Foundation framework
