### PR TITLE
Refresh the cell content instead of recreating one

### DIFF
--- a/XLForm/XL/Controllers/XLFormViewController.m
+++ b/XLForm/XL/Controllers/XLFormViewController.m
@@ -108,7 +108,8 @@
     [super viewWillAppear:animated];
     NSIndexPath *selected = [self.tableView indexPathForSelectedRow];
     if (selected){
-        [self.tableView reloadRowsAtIndexPaths:@[selected] withRowAnimation:UITableViewRowAnimationNone];
+        // Trigger a cell refresh
+        [self tableView:self.tableView cellForRowAtIndexPath:selected];
         [self.tableView selectRowAtIndexPath:selected animated:NO scrollPosition:UITableViewScrollPositionNone];
         [self.tableView selectRowAtIndexPath:nil animated:YES scrollPosition:UITableViewScrollPositionNone];
     }


### PR DESCRIPTION
This is related to my issue #132.

Instead of tell the UITableView to refresh the cell even thought we don't care about the animation, we just refresh the cell content.