### PR TITLE
Resolves issue #46 by providing a readonly property for the form

### DIFF
--- a/Examples/Others/CustomCells/XLFormImageSelectorCell.m
+++ b/Examples/Others/CustomCells/XLFormImageSelectorCell.m
@@ -93,6 +93,9 @@ NSString *const kFormImageSelectorCellImageRequest = @"imageRequest";
 
 -(void)formDescriptorCellDidSelectedWithFormController:(XLFormViewController *)controller
 {
+    if (self.formViewController.readOnlyMode) {
+        return;
+    }
     UIActionSheet *actionSheet = [[UIActionSheet alloc] initWithTitle:self.rowDescriptor.selectorTitle delegate:self
                                                     cancelButtonTitle:NSLocalizedString(@"Cancel", nil)
                                                destructiveButtonTitle:nil
@@ -107,13 +110,13 @@ NSString *const kFormImageSelectorCellImageRequest = @"imageRequest";
 {
     NSDictionary *uiComponents = @{ @"image" : self.imageView,
                                     @"text"  : self.textLabel};
-    
+
     NSDictionary *metrics = @{@"margin":@5.0};
-    
+
     [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-(margin)-[text]" options:0 metrics:metrics views:uiComponents]];
     [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(margin)-[text]" options:0 metrics:metrics views:uiComponents]];
-    
-    
+
+
     [self.contentView addConstraint:[NSLayoutConstraint constraintWithItem:self.imageView
                                                                 attribute:NSLayoutAttributeTop
                                                                 relatedBy:NSLayoutRelationEqual
@@ -129,7 +132,7 @@ NSString *const kFormImageSelectorCellImageRequest = @"imageRequest";
                                                                  attribute:NSLayoutAttributeBottom
                                                                 multiplier:1.0f
                                                                   constant:-10.0f]];
-    
+
     [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:[image(width)]" options:0 metrics:@{ @"width" : @(_imageWidth) } views:uiComponents]];
     [self.contentView addConstraint:[NSLayoutConstraint constraintWithItem:self.imageView
                                                                           attribute:NSLayoutAttributeCenterX
@@ -149,7 +152,7 @@ NSString *const kFormImageSelectorCellImageRequest = @"imageRequest";
 
 -(void)updateConstraints
 {
-    
+
     [super updateConstraints];
 }
 
@@ -206,7 +209,7 @@ NSString *const kFormImageSelectorCellImageRequest = @"imageRequest";
         }
         [self setImageValue:imageToUse];
     }
-    
+
     [self.formViewController dismissViewControllerAnimated:YES completion:nil];
 }
 

--- a/XLForm/XL/Cell/XLFormBaseCell.h
+++ b/XLForm/XL/Cell/XLFormBaseCell.h
@@ -34,8 +34,7 @@
 @interface XLFormBaseCell : UITableViewCell<XLFormDescriptorCell>
 
 @property (nonatomic, weak) XLFormRowDescriptor * rowDescriptor;
-
--(XLFormViewController *)formViewController;
+@property (nonatomic, weak) XLFormViewController * formViewController;
 
 @end
 

--- a/XLForm/XL/Cell/XLFormBaseCell.m
+++ b/XLForm/XL/Cell/XLFormBaseCell.m
@@ -59,17 +59,4 @@
     // override
 }
 
--(XLFormViewController *)formViewController
-{
-    id responder = self;
-    while (responder){
-        if ([responder isKindOfClass:[UIViewController class]]){
-            return responder;
-        }
-        responder = [responder nextResponder];
-    }
-    return nil;
-}
-
-
 @end

--- a/XLForm/XL/Cell/XLFormCheckCell.m
+++ b/XLForm/XL/Cell/XLFormCheckCell.m
@@ -41,10 +41,16 @@
     self.textLabel.text = self.rowDescriptor.title;
     self.accessoryType = [self.rowDescriptor.value boolValue] ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;
     self.textLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
+    self.selectionStyle = self.rowDescriptor.disabled || self.formViewController.readOnlyMode ? UITableViewCellSelectionStyleNone : UITableViewCellSelectionStyleDefault;
+
 }
 
 -(void)formDescriptorCellDidSelectedWithFormController:(XLFormViewController *)controller
 {
+    if (controller.readOnlyMode) {
+        return;
+    }
+
     self.rowDescriptor.value = [NSNumber numberWithBool:![self.rowDescriptor.value boolValue]];
     [self update];
     [controller.tableView deselectRowAtIndexPath:[controller.form indexPathOfFormRow:self.rowDescriptor] animated:YES];

--- a/XLForm/XL/Cell/XLFormDateCell.m
+++ b/XLForm/XL/Cell/XLFormDateCell.m
@@ -84,21 +84,25 @@
 -(void)update
 {
     [super update];
-    
+
     self.accessoryType =  UITableViewCellAccessoryNone;
     [self.textLabel setText:self.rowDescriptor.title];
     self.textLabel.textColor  = self.rowDescriptor.disabled ? [UIColor grayColor] : [UIColor blackColor];
-    self.selectionStyle = self.rowDescriptor.disabled ? UITableViewCellSelectionStyleNone : UITableViewCellSelectionStyleDefault;
-    
+    self.selectionStyle = self.rowDescriptor.disabled || self.formViewController.readOnlyMode ? UITableViewCellSelectionStyleNone : UITableViewCellSelectionStyleDefault;
+
     self.textLabel.text = [NSString stringWithFormat:@"%@%@", self.rowDescriptor.title, self.rowDescriptor.required ? @"*" : @""];
     self.detailTextLabel.text = [self valueDisplayText];
     self.textLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
     self.detailTextLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
-    
+
 }
 
 -(void)formDescriptorCellDidSelectedWithFormController:(XLFormViewController *)controller
 {
+    if (controller.readOnlyMode) {
+        return;
+    }
+
     if ([self.rowDescriptor.rowType isEqualToString:XLFormRowDescriptorTypeDateInline] || [self.rowDescriptor.rowType isEqualToString:XLFormRowDescriptorTypeTimeInline] || [self.rowDescriptor.rowType isEqualToString:XLFormRowDescriptorTypeDateTimeInline])
     {
         if ([self isFirstResponder]){
@@ -167,16 +171,16 @@
     else{
         datePicker.datePickerMode = UIDatePickerModeDateAndTime;
     }
-    
+
     if (self.minuteInterval)
         datePicker.minuteInterval = self.minuteInterval;
-    
+
     if (self.minimumDate)
         datePicker.minimumDate = self.minimumDate;
-    
+
     if (self.maximumDate)
         datePicker.maximumDate = self.maximumDate;
-    
+
 }
 
 #pragma mark - Properties
@@ -198,7 +202,7 @@
     self.detailTextLabel.text = [self formattedDate:sender.date];
     self.rowDescriptor.value = sender.date;
     [self setNeedsLayout];
-    
+
 }
 
 -(void)setFormDatePickerMode:(XLFormDateDatePickerMode)formDatePickerMode

--- a/XLForm/XL/Cell/XLFormInlineSelectorCell.m
+++ b/XLForm/XL/Cell/XLFormInlineSelectorCell.m
@@ -64,7 +64,7 @@
     self.accessoryType = UITableViewCellAccessoryNone;
     [self.textLabel setText:self.rowDescriptor.title];
     self.textLabel.textColor  = self.rowDescriptor.disabled ? [UIColor grayColor] : [UIColor blackColor];
-    self.selectionStyle = self.rowDescriptor.disabled ? UITableViewCellSelectionStyleNone : UITableViewCellSelectionStyleDefault;
+    self.selectionStyle = self.rowDescriptor.disabled || self.formViewController.readOnlyMode ? UITableViewCellSelectionStyleNone : UITableViewCellSelectionStyleDefault;
     self.textLabel.text = [NSString stringWithFormat:@"%@%@", self.rowDescriptor.title, self.rowDescriptor.required ? @"*" : @""];
     self.detailTextLabel.text = [self valueDisplayText];
     self.textLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
@@ -78,6 +78,9 @@
 
 -(void)formDescriptorCellDidSelectedWithFormController:(XLFormViewController *)controller
 {
+    if (controller.readOnlyMode) {
+        return;
+    }
     if ([self isFirstResponder]){
         [self resignFirstResponder];
     }

--- a/XLForm/XL/Cell/XLFormLeftRightSelectorCell.m
+++ b/XLForm/XL/Cell/XLFormLeftRightSelectorCell.m
@@ -54,14 +54,14 @@
     [imageView setTranslatesAutoresizingMaskIntoConstraints:NO];
     [_leftButton addSubview:imageView];
     [_leftButton addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:[image(8)]|" options:0 metrics:0 views:@{@"image": imageView}]];
-    
+
     UIView * separatorTop = [UIView autolayoutView];
     UIView * separatorBottom = [UIView autolayoutView];
     [_leftButton addSubview:separatorTop];
     [_leftButton addSubview:separatorBottom];
     [_leftButton addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[separatorTop(separatorBottom)][image][separatorBottom]|" options:0 metrics:0 views:@{@"image": imageView, @"separatorTop": separatorTop, @"separatorBottom": separatorBottom}]];
     _leftButton.titleEdgeInsets = UIEdgeInsetsMake(0, 0, 0, 15);
-    
+
     [_leftButton setTitleColor:[UIColor colorWithRed:0.0 green:0.478431 blue:1.0 alpha:1.0] forState:UIControlStateNormal];
     [_leftButton setTitleColor:[UIColor grayColor] forState:UIControlStateDisabled];
     [_leftButton setContentHuggingPriority:500 forAxis:UILayoutConstraintAxisHorizontal];
@@ -118,7 +118,7 @@
     [self.contentView addSubview:self.leftButton];
     [self.contentView addSubview:self.rightLabel];
     [self.contentView addSubview:separatorView];
-    
+
     NSDictionary * views = @{@"leftButton" : self.leftButton, @"rightLabel": self.rightLabel, @"separatorView": separatorView, @"constraintTextField": _constraintTextField };
     [self.contentView addConstraint:[NSLayoutConstraint constraintWithItem:self.leftButton attribute:NSLayoutAttributeCenterY relatedBy:NSLayoutRelationEqual toItem:self.contentView attribute:NSLayoutAttributeCenterY multiplier:1.0f constant:0.0f]];
     [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[constraintTextField]" options:0 metrics:nil views:views]];
@@ -135,10 +135,12 @@
     self.rightLabel.text = [self rightTextLabel];
     [self.leftButton setEnabled:(!self.rowDescriptor.disabled)];
     self.accessoryView = self.rowDescriptor.disabled ? nil : [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"XLForm.bundle/forwardarrow.png"]];
-    self.selectionStyle = self.rowDescriptor.disabled ? UITableViewCellSelectionStyleNone : UITableViewCellSelectionStyleDefault;    
+    self.selectionStyle = self.rowDescriptor.disabled || self.formViewController.readOnlyMode ? UITableViewCellSelectionStyleNone : UITableViewCellSelectionStyleDefault;
     self.leftButton.titleLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
     self.rightLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
     _constraintTextField.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
+
+    self.leftButton.userInteractionEnabled = !self.formViewController.readOnlyMode;
 }
 
 
@@ -150,6 +152,9 @@
 
 -(void)formDescriptorCellDidSelectedWithFormController:(XLFormViewController *)controller
 {
+    if (controller.readOnlyMode) {
+        return;
+    }
     if (self.rowDescriptor.leftRightSelectorLeftOptionSelected){
         XLFormLeftRightSelectorOption * option = [self leftOptionForOption:self.rowDescriptor.leftRightSelectorLeftOptionSelected];
         if (option.rightOptions){

--- a/XLForm/XL/Cell/XLFormPickerCell.m
+++ b/XLForm/XL/Cell/XLFormPickerCell.m
@@ -71,6 +71,9 @@
     [self.pickerView selectRow:[self selectedIndex] inComponent:0 animated:NO];
     [self.pickerView reloadAllComponents];
     
+    self.selectionStyle = self.formViewController.readOnlyMode ? UITableViewCellSelectionStyleNone : UITableViewCellSelectionStyleDefault;
+    self.pickerView.userInteractionEnabled = !self.formViewController.readOnlyMode;
+
 }
 
 +(CGFloat)formDescriptorCellHeightForRowDescriptor:(XLFormRowDescriptor *)rowDescriptor

--- a/XLForm/XL/Cell/XLFormSegmentedCell.m
+++ b/XLForm/XL/Cell/XLFormSegmentedCell.m
@@ -60,6 +60,7 @@ NSString * const kText = @"text";
     [self updateSegmentedControl];
     self.segmentedControl.selectedSegmentIndex = [self selectedIndex];
     self.textLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
+    self.segmentedControl.userInteractionEnabled = !self.formViewController.readOnlyMode;
 }
 
 #pragma mark - KVO

--- a/XLForm/XL/Cell/XLFormSelectorCell.m
+++ b/XLForm/XL/Cell/XLFormSelectorCell.m
@@ -69,8 +69,8 @@
                 else{
                     [descriptionArray addObject:[option displayText]];
                 }
-                
-                
+
+
             }
         }
         return [descriptionArray componentsJoinedByString:@", "];
@@ -131,23 +131,24 @@
     self.accessoryType = self.rowDescriptor.disabled || !([self.rowDescriptor.rowType isEqualToString:XLFormRowDescriptorTypeSelectorPush] || [self.rowDescriptor.rowType isEqualToString:XLFormRowDescriptorTypeMultipleSelector]) ? UITableViewCellAccessoryNone : UITableViewCellAccessoryDisclosureIndicator;
     [self.textLabel setText:self.rowDescriptor.title];
     self.textLabel.textColor  = self.rowDescriptor.disabled ? [UIColor grayColor] : [UIColor blackColor];
-    self.selectionStyle = self.rowDescriptor.disabled || [self.rowDescriptor.rowType isEqualToString:XLFormRowDescriptorTypeInfo] ? UITableViewCellSelectionStyleNone : UITableViewCellSelectionStyleDefault;
+    self.selectionStyle = self.rowDescriptor.disabled || self.formViewController.readOnlyMode || [self.rowDescriptor.rowType isEqualToString:XLFormRowDescriptorTypeInfo] ? UITableViewCellSelectionStyleNone : UITableViewCellSelectionStyleDefault;
     self.textLabel.text = [NSString stringWithFormat:@"%@%@", self.rowDescriptor.title, self.rowDescriptor.required ? @"*" : @""];
     self.detailTextLabel.text = [self valueDisplayText];
     self.textLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
     self.detailTextLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
-    
 }
 
 -(void)formDescriptorCellDidSelectedWithFormController:(XLFormViewController *)controller
 {
-	
+    if (controller.readOnlyMode) {
+        return;
+    }
     if ([self.rowDescriptor.rowType isEqualToString:XLFormRowDescriptorTypeSelectorPush] || [self.rowDescriptor.rowType isEqualToString:XLFormRowDescriptorTypeSelectorPopover]){
         if (self.rowDescriptor.selectorOptions){
             XLFormOptionsViewController * optionsViewController = [[XLFormOptionsViewController alloc] initWithOptions:self.rowDescriptor.selectorOptions style:UITableViewStyleGrouped titleHeaderSection:nil titleFooterSection:nil];
             optionsViewController.rowDescriptor = self.rowDescriptor;
             optionsViewController.title = self.rowDescriptor.selectorTitle;
-			
+
 			if ([self.rowDescriptor.rowType isEqualToString:XLFormRowDescriptorTypeSelectorPopover]) {
 				self.popoverController = [[UIPopoverController alloc] initWithContentViewController:optionsViewController];
                 self.popoverController.delegate = self;
@@ -168,12 +169,12 @@
             UIViewController<XLFormRowDescriptorViewController> *selectorViewController = [[selectorClass alloc] init];
             selectorViewController.rowDescriptor = self.rowDescriptor;
             selectorViewController.title = self.rowDescriptor.selectorTitle;
-            
+
             if ([self.rowDescriptor.rowType isEqualToString:XLFormRowDescriptorTypeSelectorPopover]) {
                 if (self.popoverController && self.popoverController.popoverVisible) {
                     [self.popoverController dismissPopoverAnimated:NO];
                 }
-                
+
                 UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:selectorViewController];
                 self.popoverController = [[UIPopoverController alloc] initWithContentViewController:navigationController];
                 self.popoverController.delegate = self;
@@ -199,7 +200,7 @@
         XLFormOptionsViewController * optionsViewController = [[XLFormOptionsViewController alloc] initWithOptions:self.rowDescriptor.selectorOptions style:UITableViewStyleGrouped titleHeaderSection:nil titleFooterSection:nil];
         optionsViewController.rowDescriptor = self.rowDescriptor;
         optionsViewController.title = self.rowDescriptor.selectorTitle;
-        
+
         if ([self.rowDescriptor.rowType isEqualToString:XLFormRowDescriptorTypeMultipleSelectorPopover]) {
             self.popoverController = [[UIPopoverController alloc] initWithContentViewController:optionsViewController];
             self.popoverController.delegate = self;
@@ -246,7 +247,7 @@
 {
     if (self.rowDescriptor.required && self.rowDescriptor.value == nil){
         return [[NSError alloc] initWithDomain:XLFormErrorDomain code:XLFormErrorCodeRequired userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:NSLocalizedString(@"%@ can't be empty", nil), self.rowDescriptor.title] }];
-        
+
     }
     return nil;
 }

--- a/XLForm/XL/Cell/XLFormSliderCell.m
+++ b/XLForm/XL/Cell/XLFormSliderCell.m
@@ -38,35 +38,37 @@
 
 - (void)configure
 {
-	
+
 	self.steps = 0;
-	
+
 	self.slider = [UISlider autolayoutView];
 	[self.slider addTarget:self action:@selector(valueChanged:) forControlEvents:UIControlEventValueChanged];
 	[self.contentView addSubview:self.slider];
 	self.selectionStyle = UITableViewCellSelectionStyleNone;
-	
+
 	self.textField = [UILabel autolayoutView];
 	[self.contentView addSubview:self.textField];
 	[self.contentView addConstraint:[NSLayoutConstraint constraintWithItem:self.textField attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:self.contentView attribute:NSLayoutAttributeTop multiplier:1 constant:10]];
 	[self.contentView addConstraint:[NSLayoutConstraint constraintWithItem:self.slider attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:self.contentView attribute:NSLayoutAttributeTop multiplier:1 constant:44]];
-	
+
 	[self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-15-[textField]-15-|" options:0 metrics:0 views:@{@"textField": self.textField}]];
-	
+
 	[self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-15-[slider]-15-|" options:0 metrics:0 views:@{@"slider": self.slider}]];
-	
+
 	[self valueChanged:nil];
 }
 
 -(void)update {
-	
+
     [super update];
     self.textField.text = self.rowDescriptor.title;
     self.textField.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
     self.slider.value = [self.rowDescriptor.value floatValue];
     self.slider.enabled = !self.rowDescriptor.disabled;
     self.textField.textColor  = self.rowDescriptor.disabled ? [UIColor grayColor] : [UIColor blackColor];
-	
+
+    self.slider.userInteractionEnabled = !self.formViewController.readOnlyMode;
+
     [self valueChanged:nil];
 }
 

--- a/XLForm/XL/Cell/XLFormStepCounterCell.m
+++ b/XLForm/XL/Cell/XLFormStepCounterCell.m
@@ -85,6 +85,8 @@
     [self stepControl].tintColor = self.rowDescriptor.disabled ? [UIColor grayColor] : self.defaultTintColor;
     self.textLabel.textColor  = self.rowDescriptor.disabled ? [UIColor grayColor] : [UIColor blackColor];
 
+    self.stepControl.userInteractionEnabled = !self.formViewController.readOnlyMode;
+
     [self valueChanged:nil];
 }
  

--- a/XLForm/XL/Cell/XLFormSwitchCell.m
+++ b/XLForm/XL/Cell/XLFormSwitchCell.m
@@ -47,6 +47,8 @@
     self.textLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
     self.textLabel.textColor  = self.rowDescriptor.disabled ? [UIColor grayColor] : [UIColor blackColor];
     self.switchControl.enabled = !self.rowDescriptor.disabled;
+
+    self.switchControl.userInteractionEnabled = !self.formViewController.readOnlyMode;
 }
 
 - (UISwitch *)switchControl

--- a/XLForm/XL/Cell/XLFormTextViewCell.m
+++ b/XLForm/XL/Cell/XLFormTextViewCell.m
@@ -141,6 +141,10 @@ NSString *const kFormTextViewCellPlaceholder = @"placeholder";
 
 #pragma mark - UITextViewDelegate
 
+-(BOOL)textViewShouldBeginEditing:(UITextView *)textView {
+    return [self.formViewController textViewShouldBeginEditing:textView];
+}
+
 -(void)textViewDidEndEditing:(UITextView *)textView{
     if([self.textView.text length] > 0) {
         self.rowDescriptor.value = self.textView.text;

--- a/XLForm/XL/Controllers/XLFormViewController.h
+++ b/XLForm/XL/Controllers/XLFormViewController.h
@@ -61,6 +61,7 @@
 @interface XLFormViewController : UITableViewController<XLFormDescriptorDelegate, UITextFieldDelegate, UITextViewDelegate, UIActionSheetDelegate, XLFormViewControllerDelegate>
 
 @property XLFormDescriptor * form;
+@property (nonatomic, assign) BOOL readOnlyMode;
 
 -(id)initWithForm:(XLFormDescriptor *)form;
 +(NSMutableDictionary *)cellClassesForRowDescriptorTypes;

--- a/XLForm/XL/Controllers/XLFormViewController.m
+++ b/XLForm/XL/Controllers/XLFormViewController.m
@@ -145,7 +145,7 @@
 +(NSMutableDictionary *)cellClassesForRowDescriptorTypes
 {
     static NSMutableDictionary * _cellClassesForRowDescriptorTypes;
-    
+
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         _cellClassesForRowDescriptorTypes = [@{XLFormRowDescriptorTypeText:[XLFormTextFieldCell class],
@@ -194,7 +194,7 @@
 +(NSMutableDictionary *)inlineRowDescriptorTypesForRowDescriptorTypes
 {
     static NSMutableDictionary * _inlineRowDescriptorTypesForRowDescriptorTypes;
-    
+
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         _inlineRowDescriptorTypesForRowDescriptorTypes = [
@@ -349,13 +349,14 @@
 {
     XLFormRowDescriptor * rowDescriptor = [self.form formRowAtIndex:indexPath];
     UITableViewCell<XLFormDescriptorCell> * formDescriptorCell = [rowDescriptor cellForFormController:self];
-    
+    ((XLFormBaseCell *)formDescriptorCell).formViewController = self;
+
     ((UITableViewCell<XLFormDescriptorCell> *)formDescriptorCell).rowDescriptor = rowDescriptor;
     [rowDescriptor.cellConfig enumerateKeysAndObjectsUsingBlock:^(NSString *keyPath, id value, BOOL * __unused stop) {
         [formDescriptorCell setValue:value forKeyPath:keyPath];
     }];
     [formDescriptorCell setNeedsLayout];
-    
+
     return formDescriptorCell;
 }
 
@@ -372,7 +373,7 @@
         [multivaluedFormSection removeFormRowAtIndex:indexPath.row];
         self.tableView.editing = NO;
         self.tableView.editing = YES;
-        
+
     }
     else if (editingStyle == UITableViewCellEditingStyleInsert){
         XLFormSectionDescriptor * multivaluedFormSection = [self.form formSectionAtIndex:indexPath.section];
@@ -447,7 +448,7 @@
     UITableViewCell<XLFormDescriptorCell> * cell = [textField formDescriptorCell];
     NSIndexPath * currentIndexPath = [self.tableView indexPathForCell:cell];
     NSIndexPath * nextIndexPath = [self nextIndexPath:currentIndexPath];
-    
+
     if (nextIndexPath){
         XLFormRowDescriptor * nextFormRow = [self.form formRowAtIndex:nextIndexPath];
         UITableViewCell<XLFormDescriptorCell> * nextCell = (UITableViewCell<XLFormDescriptorCell> *)[nextFormRow cellForFormController:self];
@@ -464,7 +465,7 @@
 
 - (BOOL)textFieldShouldBeginEditing:(UITextField *)textField
 {
-    return YES;
+    return !self.readOnlyMode;
 }
 
 - (BOOL)textFieldShouldEndEditing:(UITextField *)textField
@@ -485,6 +486,11 @@
 }
 
 #pragma mark - UITextViewDelegate
+
+- (BOOL)textViewShouldBeginEditing:(UITextView *)textView {
+    return !self.readOnlyMode;
+}
+
 
 -(void)textViewDidEndEditing:(UITextView *)textView
 {


### PR DESCRIPTION
This pull request makes it possible to set an entire form to read-only mode. 

In this case, read-only means that the cells are not disabled (and thus not grayed out), but simply don't respond to user interactions.  Only cell types that can change field values are affected.

The advantage here is that it is not necessary to reload the table view, which means that you can make the form readonly by simply changing the new readOnlyMode property on the view controller.

I had to remove the -(XLFormViewController *)formViewController selector in XLBaseCell and replace it with a weak reference that is then set in the form view controller when instantiating the cell. This was necessary because to the old selector always returned nil for cells that contain controls other than UITextField and UITextView.

To make a form read-only, simply set readOnlyMode to YES.

