### PR TITLE
Avoid Nil row name on validation message if row title is nil. 

### DIFF
--- a/XLForm/XL/Descriptors/XLFormRowDescriptor.m
+++ b/XLForm/XL/Descriptors/XLFormRowDescriptor.m
@@ -189,8 +189,13 @@
                 // default message for required msg
                 msg = NSLocalizedString(@"%@ can't be empty", nil);
             }
-            valStatus.msg = [NSString stringWithFormat:msg, self.title];
             
+            if (self.title != nil) {
+                valStatus.msg = [NSString stringWithFormat:msg, self.title];
+            } else {
+                valStatus.msg = [NSString stringWithFormat:msg, self.tag];
+            }
+
             return valStatus;
         }
     } else {


### PR DESCRIPTION
Use the row Tag instead of the title, when title is nil, when generating an error message on validation.

This is relevant to issue #182 
