### PR TITLE
fix of bug when removing row of type: XLFormRowDescriptorTypeDateTimeInline or XLFormRowDescriptorTypeDateInline

### DIFF
--- a/XLForm/XL/Descriptors/XLFormDescriptor.m
+++ b/XLForm/XL/Descriptors/XLFormDescriptor.m
@@ -142,7 +142,7 @@ NSString * const XLValidationStatusErrorKey = @"XLValidationStatusErrorKey";
 {
     for (XLFormSectionDescriptor * section in self.formSections){
         if ([section.formRows containsObject:formRow]){
-            if ([formRow.rowType isKindOfClass:[XLFormRowDescriptorTypeDateInline class]]) {
+            if ([formRow.rowType isKindOfClass:[XLFormRowDescriptorTypeDateInline class]] || [formRow.rowType isKindOfClass:[XLFormRowDescriptorTypeDateTimeInline class]]) {
                 if ([((XLFormRowDescriptor *)[section.formRows objectAtIndex:([section.formRows indexOfObject:formRow]+1)]).rowType isEqualToString:@"datePicker"]) {
                     [section removeFormRowAtIndex:[section.formRows indexOfObject:formRow]+1];
                 }

--- a/XLForm/XL/Descriptors/XLFormDescriptor.m
+++ b/XLForm/XL/Descriptors/XLFormDescriptor.m
@@ -142,6 +142,11 @@ NSString * const XLValidationStatusErrorKey = @"XLValidationStatusErrorKey";
 {
     for (XLFormSectionDescriptor * section in self.formSections){
         if ([section.formRows containsObject:formRow]){
+            if ([formRow.rowType isKindOfClass:[XLFormRowDescriptorTypeDateInline class]]) {
+                if ([((XLFormRowDescriptor *)[section.formRows objectAtIndex:([section.formRows indexOfObject:formRow]+1)]).rowType isEqualToString:@"datePicker"]) {
+                    [section removeFormRowAtIndex:[section.formRows indexOfObject:formRow]+1];
+                }
+            }
             [section removeFormRow:formRow];
         }
     }


### PR DESCRIPTION
There's a bug while trying to remove a row of types mentioned at the title, while the datePicker is being displayed: XLFormRowDescriptorTypeDateTimeInline or XLFormRowDescriptorTypeDateInline. 

If the DatePicker is being displayed, and the row is removed, the DatePicker will still be displayed, crashing the app if you select any date in it.
If it's the case of removing a row of these types, and adding them later.. After several additions and removals while Date Pickers are displayed, it will continuously generate date pickers that won't be connected to any control.
