### PR TITLE
Fail validation for empty strings and NSNull on required rows.

### DIFF
--- a/XLForm/XL/Descriptors/XLFormRowDescriptor.m
+++ b/XLForm/XL/Descriptors/XLFormRowDescriptor.m
@@ -175,12 +175,17 @@
     }
 }
 
+- (BOOL)valueIsEmpty
+{
+    return self.value == nil || [self.value isKindOfClass:[NSNull class]] || ([self.value respondsToSelector:@selector(length)] && [self.value length]==0);
+}
+
 -(XLFormValidationStatus *) doValidation {
     XLFormValidationStatus *valStatus = [XLFormValidationStatus formValidationStatusWithMsg:@"" status:YES rowDescriptor:self];
     
     if (self.required) {
         // do required validation here
-        if (self.value == nil) { // || value.length() == 0
+        if ([self valueIsEmpty]) { // || value.length() == 0
             valStatus.isValid = NO;
             NSString *msg = nil;
             if (self.requireMsg != nil) {
@@ -200,7 +205,7 @@
         }
     } else {
         // if user has not enter anything, we dun display the valid icon
-        if (self.value == nil) {// || value.length() == 0
+        if ([self valueIsEmpty]) {// || value.length() == 0
             valStatus = nil; // optional field, we will mark this validation as optional by passing null
         }
     }


### PR DESCRIPTION
`required` is not behaving as expected for Selector rows. `NSNull` instances can return and the row validates.

This PR is just one approach to correcting the issue. Please let me know if you would rather a different approach, or if the current behavior is by design.