### PR TITLE
Removed cell configuration ambiguity

### DIFF
--- a/Examples/Dates/DatesFormViewController.m
+++ b/Examples/Dates/DatesFormViewController.m
@@ -72,13 +72,13 @@ NSString *const kDateTime = @"dateTime";
         // Date
         row = [XLFormRowDescriptor formRowDescriptorWithTag:kDate rowType:XLFormRowDescriptorTypeDate title:@"Date"];
         row.value = [NSDate new];
-        [row.cellConfigAtConfigure setObject:[NSDate new] forKey:@"minimumDate"];
-        [row.cellConfigAtConfigure setObject:[NSDate dateWithTimeIntervalSinceNow:(60*60*24*3)] forKey:@"maximumDate"];
+        [row.cellConfig setObject:[NSDate new] forKey:@"minimumDate"];
+        [row.cellConfig setObject:[NSDate dateWithTimeIntervalSinceNow:(60*60*24*3)] forKey:@"maximumDate"];
         [section addFormRow:row];
         
         // DateTime
         row = [XLFormRowDescriptor formRowDescriptorWithTag:kTime rowType:XLFormRowDescriptorTypeTime title:@"Time"];
-        [row.cellConfigAtConfigure setObject:@(10) forKey:@"minuteInterval"];
+        [row.cellConfig setObject:@(10) forKey:@"minuteInterval"];
         row.value = [NSDate new];
         [section addFormRow:row];
         

--- a/Examples/Inputs/InputsFormViewController.m
+++ b/Examples/Inputs/InputsFormViewController.m
@@ -102,7 +102,7 @@ NSString *const kNotes = @"notes";
     
     
     row = [XLFormRowDescriptor formRowDescriptorWithTag:kTextView rowType:XLFormRowDescriptorTypeTextView];
-    [row.cellConfigAtConfigure setObject:@"TEXT VIEW EXAMPLE" forKey:@"textView.placeholder"];
+    [row.cellConfig setObject:@"TEXT VIEW EXAMPLE" forKey:@"textView.placeholder"];
     [section addFormRow:row];
     
     section = [XLFormSectionDescriptor formSectionWithTitle:@"TextView With Label Example"];

--- a/Examples/Others/OthersFormViewController.m
+++ b/Examples/Others/OthersFormViewController.m
@@ -92,9 +92,9 @@ NSString *const kButtonWithStoryboardId = @"buttonWithStoryboardId";
     // Slider
     row = [XLFormRowDescriptor formRowDescriptorWithTag:kSlider rowType:XLFormRowDescriptorTypeSlider title:@"Slider"];
     row.value = @(30);
-    [row.cellConfigAtConfigure setObject:@(100) forKey:@"slider.maximumValue"];
-    [row.cellConfigAtConfigure setObject:@(10) forKey:@"slider.minimumValue"];
-    [row.cellConfigAtConfigure setObject:@(4) forKey:@"steps"];
+    [row.cellConfig setObject:@(100) forKey:@"slider.maximumValue"];
+    [row.cellConfig setObject:@(10) forKey:@"slider.minimumValue"];
+    [row.cellConfig setObject:@(4) forKey:@"steps"];
     [section addFormRow:row];
     
     // Custom cell

--- a/Examples/RealExamples/NativeEventFormViewController.m
+++ b/Examples/RealExamples/NativeEventFormViewController.m
@@ -223,7 +223,7 @@
         XLFormDateCell * dateEndCell = (XLFormDateCell *)[endDateDescriptor cellForFormController:self];
         if ([startDateDescriptor.value compare:endDateDescriptor.value] == NSOrderedDescending) {
             // startDateDescriptor is later than endDateDescriptor
-            endDateDescriptor.value =  [[NSDate alloc] initWithTimeInterval:(60*60*24) sinceDate:startDateDescriptor.value];
+            endDateDescriptor.value = (NSDate *)newValue;
             [dateEndCell update];
         }
     }
@@ -233,8 +233,7 @@
         XLFormDateCell * dateEndCell = (XLFormDateCell *)[endDateDescriptor cellForFormController:self];
         if ([startDateDescriptor.value compare:endDateDescriptor.value] == NSOrderedDescending) {
             // startDateDescriptor is later than endDateDescriptor
-            NSDictionary *strikeThroughAttribute = [NSDictionary dictionaryWithObject:@1
-                                                                               forKey:NSStrikethroughStyleAttributeName];
+            NSDictionary *strikeThroughAttribute = @{NSStrikethroughStyleAttributeName:@1};
             NSAttributedString* strikeThroughText = [[NSAttributedString alloc] initWithString:dateEndCell.detailTextLabel.text attributes:strikeThroughAttribute];
             dateEndCell.detailTextLabel.attributedText = strikeThroughText;
         }

--- a/Examples/RealExamples/NativeEventFormViewController.m
+++ b/Examples/RealExamples/NativeEventFormViewController.m
@@ -80,12 +80,12 @@
     
     // Title
     row = [XLFormRowDescriptor formRowDescriptorWithTag:@"title" rowType:XLFormRowDescriptorTypeText];
-    [row.cellConfigAtConfigure setObject:@"Title" forKey:@"textField.placeholder"];
+    [row.cellConfig setObject:@"Title" forKey:@"textField.placeholder"];
     [section addFormRow:row];
     
     // Location
     row = [XLFormRowDescriptor formRowDescriptorWithTag:@"location" rowType:XLFormRowDescriptorTypeText];
-    [row.cellConfigAtConfigure setObject:@"Location" forKey:@"textField.placeholder"];
+    [row.cellConfig setObject:@"Location" forKey:@"textField.placeholder"];
     [section addFormRow:row];
     
     section = [XLFormSectionDescriptor formSection];
@@ -159,12 +159,12 @@
 
     // URL
     row = [XLFormRowDescriptor formRowDescriptorWithTag:@"url" rowType:XLFormRowDescriptorTypeURL];
-    [row.cellConfigAtConfigure setObject:@"URL" forKey:@"textField.placeholder"];
+    [row.cellConfig setObject:@"URL" forKey:@"textField.placeholder"];
     [section addFormRow:row];
     
     // Location
     row = [XLFormRowDescriptor formRowDescriptorWithTag:@"notes" rowType:XLFormRowDescriptorTypeTextView];
-    [row.cellConfigAtConfigure setObject:@"Notes" forKey:@"textView.placeholder"];
+    [row.cellConfig setObject:@"Notes" forKey:@"textView.placeholder"];
     [section addFormRow:row];
     
     

--- a/Examples/UICustomization/UICustomizationFormViewController.m
+++ b/Examples/UICustomization/UICustomizationFormViewController.m
@@ -46,7 +46,7 @@
         // Name
         row = [XLFormRowDescriptor formRowDescriptorWithTag:@"Name" rowType:XLFormRowDescriptorTypeText title:@"Name"];
         // change the background color
-        [row.cellConfigAtConfigure setObject:[UIColor greenColor] forKey:@"backgroundColor"];
+        [row.cellConfig setObject:[UIColor greenColor] forKey:@"backgroundColor"];
         // font
         [row.cellConfig setObject:[UIFont fontWithName:@"Helvetica" size:30] forKey:@"textLabel.font"];
         // background color
@@ -64,7 +64,7 @@
         
         //Button
         row = [XLFormRowDescriptor formRowDescriptorWithTag:@"Button" rowType:XLFormRowDescriptorTypeButton title:@"Button"];
-        [row.cellConfigAtConfigure setObject:[UIColor purpleColor] forKey:@"backgroundColor"];
+        [row.cellConfig setObject:[UIColor purpleColor] forKey:@"backgroundColor"];
         [row.cellConfig setObject:[UIColor whiteColor] forKey:@"textLabel.color"];
         [row.cellConfig setObject:[UIFont fontWithName:@"Helvetica" size:40] forKey:@"textLabel.font"];
         [section addFormRow:row];

--- a/XLForm/XL/Cell/XLFormDateCell.m
+++ b/XLForm/XL/Cell/XLFormDateCell.m
@@ -171,11 +171,11 @@
     
     if (self.minuteInterval)
         datePicker.minuteInterval = self.minuteInterval;
-    
-    if (self.minimumDate)
+
+    if (self.minimumDate && ![self.minimumDate isEqual:[NSNull null]])
         datePicker.minimumDate = self.minimumDate;
     
-    if (self.maximumDate)
+    if (self.maximumDate && ![self.maximumDate isEqual:[NSNull null]])
         datePicker.maximumDate = self.maximumDate;
 }
 

--- a/XLForm/XL/Descriptors/XLFormRowDescriptor.h
+++ b/XLForm/XL/Descriptors/XLFormRowDescriptor.h
@@ -51,7 +51,6 @@ typedef NS_ENUM(NSUInteger, XLFormPresentationMode) {
 @property UITableViewCellStyle cellStyle;
 
 @property (nonatomic) NSMutableDictionary *cellConfig;
-@property (nonatomic) NSMutableDictionary *cellConfigAtConfigure;
 @property BOOL disabled;
 @property BOOL required;
 

--- a/XLForm/XL/Descriptors/XLFormRowDescriptor.m
+++ b/XLForm/XL/Descriptors/XLFormRowDescriptor.m
@@ -73,25 +73,15 @@
         UITableViewCell<XLFormDescriptorCell> * reuseCell = [formController.tableView dequeueReusableCellWithIdentifier:cellClass];
         if (reuseCell){
             _cell  = reuseCell;
-            [self configureCellAtCreationTime];
         }
         else if (!_cell && [[NSBundle mainBundle] pathForResource:cellClass ofType:@"nib"]){
             _cell = [[[NSBundle mainBundle] loadNibNamed:cellClass owner:nil options:nil] firstObject];
-            [self configureCellAtCreationTime];
         }
     } else if (!_cell) {
         _cell = [[cellClass alloc] initWithStyle:self.cellStyle reuseIdentifier:nil];
-        [self configureCellAtCreationTime];
     }
     NSAssert([_cell isKindOfClass:[UITableViewCell class]] && [_cell conformsToProtocol:@protocol(XLFormDescriptorCell)], @"Can not get a UITableViewCell form cellClass");
     return _cell;
-}
-
-- (void) configureCellAtCreationTime
-{
-    [self.cellConfigAtConfigure enumerateKeysAndObjectsUsingBlock:^(NSString *keyPath, id value, __unused BOOL *stop) {
-        [_cell setValue:(value == [NSNull null]) ? nil : value forKeyPath:keyPath];
-    }];
 }
 
 -(NSMutableDictionary *)cellConfig
@@ -99,13 +89,6 @@
     if (_cellConfig) return _cellConfig;
     _cellConfig = [NSMutableDictionary dictionary];
     return _cellConfig;
-}
-
--(NSMutableDictionary *)cellConfigAtConfigure
-{
-    if (_cellConfigAtConfigure) return _cellConfigAtConfigure;
-    _cellConfigAtConfigure = [NSMutableDictionary dictionary];
-    return _cellConfigAtConfigure;
 }
 
 -(NSString *)description
@@ -132,7 +115,6 @@
     XLFormRowDescriptor * rowDescriptorCopy = [XLFormRowDescriptor formRowDescriptorWithTag:[self.tag copy] rowType:[self.rowType copy] title:[self.title copy]];
     rowDescriptorCopy.cellClass = [self.cellClass copy];
     rowDescriptorCopy.cellConfig = [self.cellConfig mutableCopy];
-    rowDescriptorCopy.cellConfigAtConfigure = [self.cellConfigAtConfigure mutableCopy];
     rowDescriptorCopy.disabled = self.disabled;
     rowDescriptorCopy.required = self.required;
     


### PR DESCRIPTION
# Description
The properties `cellConfigAtConfigure` and `cellConfig` have the same purpose. To improve the clarity of the code, `cellConfigAtConfigure` and all of its references, including the method `configureCellAtCreationTime`, were removed.

- Removed the property `cellConfigAtConfigure`
- Removed the method `configureCellAtCreationTime`
- Removed the method `cellConfigureAtConfigure`

# Issue
This solved #246 