### PR TITLE
Allow subclass to override the textField and textLabel

### DIFF
--- a/XLForm/XL/Cell/XLFormTextFieldCell.h
+++ b/XLForm/XL/Cell/XLFormTextFieldCell.h
@@ -32,4 +32,7 @@
 @property (nonatomic, readonly) UILabel * textLabel;
 @property (nonatomic, readonly) UITextField * textField;
 
+-(UITextField *)createTextField;
+-(UILabel *)createTextLabel;
+
 @end

--- a/XLForm/XL/Cell/XLFormTextFieldCell.m
+++ b/XLForm/XL/Cell/XLFormTextFieldCell.m
@@ -154,17 +154,27 @@
 -(UILabel *)textLabel
 {
     if (_textLabel) return _textLabel;
-    _textLabel = [UILabel autolayoutView];
+    _textLabel = [self createTextLabel];
     [_textLabel setFont:[UIFont preferredFontForTextStyle:UIFontTextStyleBody]];
     return _textLabel;
+}
+
+-(UILabel *)createTextLabel
+{
+    return [UILabel autolayoutView];
 }
 
 -(UITextField *)textField
 {
     if (_textField) return _textField;
-    _textField = [UITextField autolayoutView];
+    _textField = [self createTextField];
     [_textField setFont:[UIFont preferredFontForTextStyle:UIFontTextStyleBody]];
     return _textField;
+}
+
+-(UITextField *)createTextField
+{
+    return [UITextField autolayoutView];
 }
 
 #pragma mark - LayoutConstraints


### PR DESCRIPTION
Useful when using UITextField subclasses such as JVFloatLabeledTextField