### PR TITLE
Fix for the UITableView inset when using a form into a UITabBarController

### DIFF
--- a/XLForm/XL/Controllers/XLFormViewController.m
+++ b/XLForm/XL/Controllers/XLFormViewController.m
@@ -429,7 +429,7 @@
         NSDictionary *keyboardInfo = [notification userInfo];
         UIEdgeInsets tableContentInset = self.tableView.contentInset;
         UIEdgeInsets tableScrollIndicatorInsets = self.tableView.scrollIndicatorInsets;
-        tableContentInset.bottom = 0;
+        tableContentInset.bottom = self.bottomLayoutGuide.length;
         tableScrollIndicatorInsets.bottom = tableContentInset.bottom;
         [UIView beginAnimations:nil context:nil];
         [UIView setAnimationDuration:[keyboardInfo[UIKeyboardAnimationDurationUserInfoKey] doubleValue]];


### PR DESCRIPTION
When a XLFormViewController is displayed into a `UITabBarController`, after the keyboard is dismissed, the `keyboardWillHide:` method sets the `UITableView` content and scroll bottom insets to `0` hiding the last section of the form under the `UITabBar`.
