### PR TITLE
Update Podfile of examples

### DIFF
--- a/Examples/Objective-C/Podfile.lock
+++ b/Examples/Objective-C/Podfile.lock
@@ -1,30 +1,30 @@
 PODS:
-  - AFNetworking (2.4.1):
-    - AFNetworking/NSURLConnection (= 2.4.1)
-    - AFNetworking/NSURLSession (= 2.4.1)
-    - AFNetworking/Reachability (= 2.4.1)
-    - AFNetworking/Security (= 2.4.1)
-    - AFNetworking/Serialization (= 2.4.1)
-    - AFNetworking/UIKit (= 2.4.1)
-  - AFNetworking/NSURLConnection (2.4.1):
+  - AFNetworking (2.5.2):
+    - AFNetworking/NSURLConnection (= 2.5.2)
+    - AFNetworking/NSURLSession (= 2.5.2)
+    - AFNetworking/Reachability (= 2.5.2)
+    - AFNetworking/Security (= 2.5.2)
+    - AFNetworking/Serialization (= 2.5.2)
+    - AFNetworking/UIKit (= 2.5.2)
+  - AFNetworking/NSURLConnection (2.5.2):
     - AFNetworking/Reachability
     - AFNetworking/Security
     - AFNetworking/Serialization
-  - AFNetworking/NSURLSession (2.4.1):
+  - AFNetworking/NSURLSession (2.5.2):
     - AFNetworking/Reachability
     - AFNetworking/Security
     - AFNetworking/Serialization
-  - AFNetworking/Reachability (2.4.1)
-  - AFNetworking/Security (2.4.1)
-  - AFNetworking/Serialization (2.4.1)
-  - AFNetworking/UIKit (2.4.1):
+  - AFNetworking/Reachability (2.5.2)
+  - AFNetworking/Security (2.5.2)
+  - AFNetworking/Serialization (2.5.2)
+  - AFNetworking/UIKit (2.5.2):
     - AFNetworking/NSURLConnection
     - AFNetworking/NSURLSession
   - AXRatingView (1.0.3)
   - JVFloatLabeledTextField (1.0.2)
   - XLDataLoader (1.1.0):
     - AFNetworking (~> 2.0)
-  - XLForm (2.1.0)
+  - XLForm (2.2.0)
 
 DEPENDENCIES:
   - AFNetworking (~> 2.0)
@@ -35,13 +35,13 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   XLForm:
-    :path: ../../
+    :path: "../../"
 
 SPEC CHECKSUMS:
-  AFNetworking: 0aabc6fae66d6e5d039eeb21c315843c7aae51ab
-  AXRatingView: 4f6d6c96f6d0efc1deaa6cf493dbb1ffcfa79e55
-  JVFloatLabeledTextField: c1ad6b4b5bd77115cfe6c71ba4c023866df5c4cf
-  XLDataLoader: bd783ebe782932a6390ffc7619fcd884c8600944
-  XLForm: c87bc94f769f52ce32793282d72d2fb15d0d5638
+  AFNetworking: fefbce9660acb17f48ae0011292d4da0f457bf36
+  AXRatingView: ccaadc1bbda99a4b7e1d556059482d2b933a9f4e
+  JVFloatLabeledTextField: 58a3a32cfb800e5b224f676987e7c13abf50a14d
+  XLDataLoader: 7d466e086f4b6ecd144e880be8232adbe80aef52
+  XLForm: 799e61ef230f519914e722bf032b19a597223c19
 
-COCOAPODS: 0.35.0
+COCOAPODS: 0.36.3

--- a/Examples/Swift/Podfile.lock
+++ b/Examples/Swift/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
-  - XLForm (2.1.0)
+  - XLForm (2.2.0)
 
 DEPENDENCIES:
   - XLForm (from `../../`)
 
 EXTERNAL SOURCES:
   XLForm:
-    :path: ../../
+    :path: "../../"
 
 SPEC CHECKSUMS:
-  XLForm: c87bc94f769f52ce32793282d72d2fb15d0d5638
+  XLForm: 799e61ef230f519914e722bf032b19a597223c19
 
-COCOAPODS: 0.35.0
+COCOAPODS: 0.36.3


### PR DESCRIPTION
The `Podfile.lock` of the examples was out of date resulting in errors when using `pod try`.