### PR TITLE
Add support for NSFormatter

### DIFF
--- a/Examples/Objective-C/Examples/ExamplesFormViewController.m
+++ b/Examples/Objective-C/Examples/ExamplesFormViewController.m
@@ -34,6 +34,7 @@
 #import "CustomRowsViewController.h"
 #import "AccessoryViewFormViewController.h"
 #import "PredicateFormViewController.h"
+#import "FormattersViewController.h"
 
 NSString * const kTextFieldAndTextView = @"TextFieldAndTextView";
 NSString * const kSelectors = @"Selectors";
@@ -46,6 +47,7 @@ NSString * const kMultivaluedOnlyReorder = @"MultivaluedOnlyReorder";
 NSString * const kMultivaluedOnlyInsert = @"MultivaluedOnlyInsert";
 NSString * const kMultivaluedOnlyDelete = @"MultivaluedOnlyDelete";
 NSString * const kValidations= @"Validations";
+NSString * const kFormatters = @"Formatters";
 
 @interface ExamplesFormViewController ()
 
@@ -111,6 +113,11 @@ NSString * const kValidations= @"Validations";
     // Dates
     row = [XLFormRowDescriptor formRowDescriptorWithTag:kDates rowType:XLFormRowDescriptorTypeButton title:@"Date & Time"];
     row.action.viewControllerClass = [DatesFormViewController class];
+    [section addFormRow:row];
+    
+    // NSFormatters
+    row = [XLFormRowDescriptor formRowDescriptorWithTag:kFormatters rowType:XLFormRowDescriptorTypeButton title:@"NSFormatter Support"];
+    row.action.viewControllerClass = [FormattersViewController class];
     [section addFormRow:row];
     
     // Others

--- a/Examples/Objective-C/Examples/Formatters/FormattersViewController.h
+++ b/Examples/Objective-C/Examples/Formatters/FormattersViewController.h
@@ -1,0 +1,13 @@
+//
+//  FormattersViewController.h
+//  XLForm
+//
+//  Created by Freddy Henin on 12/29/14.
+//  Copyright (c) 2014 Xmartlabs. All rights reserved.
+//
+
+#import "XLFormViewController.h"
+
+@interface FormattersViewController : XLFormViewController
+
+@end

--- a/Examples/Objective-C/Examples/Formatters/FormattersViewController.m
+++ b/Examples/Objective-C/Examples/Formatters/FormattersViewController.m
@@ -1,0 +1,115 @@
+//
+//  FormattersViewController.m
+//  XLForm
+//
+//  Created by Freddy Henin on 12/29/14.
+//  Copyright (c) 2014 Xmartlabs. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+
+#import "XLForm.h"
+
+#import "FormattersViewController.h"
+
+#import <SHSPhoneComponent/SHSPhoneNumberFormatter+UserConfig.h>
+
+
+// Simple little class to demonstraite currency formatting.   Unfortunally we have to subclass
+// NSNumberFormatter to work aroundn some long known rounding bugs with NSNumberFormatter
+//     http://stackoverflow.com/questions/12580162/nsstring-to-nsdate-conversion-issue
+@interface CurrencyFormatter : NSNumberFormatter
+
+@property (readonly) NSDecimalNumberHandler *roundingBehavior;
+
+@end
+
+@implementation CurrencyFormatter
+
+- (id) init
+{
+    self = [super init];
+    if (self) {
+        [self setNumberStyle: NSNumberFormatterCurrencyStyle];
+        [self setGeneratesDecimalNumbers:YES];
+        
+        NSUInteger currencyScale = [self maximumFractionDigits];
+        
+        _roundingBehavior = [NSDecimalNumberHandler decimalNumberHandlerWithRoundingMode:NSRoundPlain scale:currencyScale raiseOnExactness:FALSE raiseOnOverflow:TRUE raiseOnUnderflow:TRUE raiseOnDivideByZero:TRUE];
+        
+    }
+    
+    return self;
+}
+
+//- (BOOL)getObjectValue:(id *)anObject forString:(NSString *)string errorDescription:(NSString **)error
+//{
+//    NSDecimalNumber *number;
+//    BOOL success = [super getObjectValue:&number forString:string errorDescription:error];
+//    
+//    if (success) {
+//        *anObject = [number decimalNumberByRoundingAccordingToBehavior:_roundingBehavior];
+//    }
+//    else {
+//        *anObject = nil;
+//    }
+//    
+//    return success;
+//}
+
+@end
+
+@interface FormattersViewController ()
+@end
+
+@implementation FormattersViewController
+
+-(id)init
+{
+    XLFormDescriptor * formDescriptor = [XLFormDescriptor formDescriptorWithTitle:@"Text Fields"];
+    XLFormSectionDescriptor * section;
+    XLFormRowDescriptor * row;
+    
+    formDescriptor.assignFirstResponderOnShow = NO;
+    
+    section = [XLFormSectionDescriptor formSection];
+    section.title = @"NSFormatter Support";
+    section.footerTitle = @"Rows can be configured to use the formatter as you type or to toggle on and off during for display/editing.  You will most likely need custom NSFormatter objects to do on the fly formatting since NSNumberFormatter is pretty limited in this regard.";
+    [formDescriptor addFormSection:section];
+    
+    // Phone
+    SHSPhoneNumberFormatter *formatter = [[SHSPhoneNumberFormatter alloc] init];
+    [formatter setDefaultOutputPattern:@"(###) ###-####" imagePath:nil];
+    row = [XLFormRowDescriptor formRowDescriptorWithTag:@"phone" rowType:XLFormRowDescriptorTypePhone title:@"US Phone"];
+    row.valueFormatter = formatter;
+    [row.cellConfigAtConfigure setObject:@(NSTextAlignmentRight) forKey:@"textField.textAlignment"];
+    
+    row.useValueFormatterDuringInput = YES;
+    [section addFormRow:row];
+    
+    // Currency
+    row = [XLFormRowDescriptor formRowDescriptorWithTag:@"currency" rowType:XLFormRowDescriptorTypeDecimal title:@"USD"];
+    CurrencyFormatter *numberFormatter = [[CurrencyFormatter alloc] init];
+    row.valueFormatter = numberFormatter;
+    row.value = [NSDecimalNumber numberWithDouble:9.95];
+    [row.cellConfigAtConfigure setObject:@(NSTextAlignmentRight) forKey:@"textField.textAlignment"];
+    [section addFormRow:row];
+    
+    // Accounting
+    row = [XLFormRowDescriptor formRowDescriptorWithTag:@"percent" rowType:XLFormRowDescriptorTypeNumber title:@"Test Score"];
+    NSNumberFormatter *acctFormatter = [[NSNumberFormatter alloc] init];
+    [acctFormatter setNumberStyle:NSNumberFormatterPercentStyle];
+    row.valueFormatter = acctFormatter;
+    row.value = @(0.75);
+    [row.cellConfigAtConfigure setObject:@(NSTextAlignmentRight) forKey:@"textField.textAlignment"];
+    [section addFormRow:row];
+    
+    section = [XLFormSectionDescriptor formSection];
+    [formDescriptor addFormSection:section];
+    
+    return [super initWithForm:formDescriptor];
+    
+}
+
+@end

--- a/Examples/Objective-C/Podfile
+++ b/Examples/Objective-C/Podfile
@@ -10,5 +10,5 @@ pod 'AFNetworking', '~> 2.0', :inhibit_warnings => true
 pod 'XLData', :git => 'https://github.com/xmartlabs/XLData.git', :commit => '1f9019b56242a2019c7f7e11ec4ef823c397ebcf', :inhibit_warnings => true
 pod 'JVFloatLabeledTextField', '1.0.2', :inhibit_warnings => true
 pod 'AXRatingView', '1.0.3', :inhibit_warnings => true
-
+pod 'SHSPhoneComponent'
 end

--- a/Examples/Objective-C/Podfile.lock
+++ b/Examples/Objective-C/Podfile.lock
@@ -1,0 +1,50 @@
+PODS:
+  - AFNetworking (2.5.2):
+    - AFNetworking/NSURLConnection (= 2.5.2)
+    - AFNetworking/NSURLSession (= 2.5.2)
+    - AFNetworking/Reachability (= 2.5.2)
+    - AFNetworking/Security (= 2.5.2)
+    - AFNetworking/Serialization (= 2.5.2)
+    - AFNetworking/UIKit (= 2.5.2)
+  - AFNetworking/NSURLConnection (2.5.2):
+    - AFNetworking/Reachability
+    - AFNetworking/Security
+    - AFNetworking/Serialization
+  - AFNetworking/NSURLSession (2.5.2):
+    - AFNetworking/Reachability
+    - AFNetworking/Security
+    - AFNetworking/Serialization
+  - AFNetworking/Reachability (2.5.2)
+  - AFNetworking/Security (2.5.2)
+  - AFNetworking/Serialization (2.5.2)
+  - AFNetworking/UIKit (2.5.2):
+    - AFNetworking/NSURLConnection
+    - AFNetworking/NSURLSession
+  - AXRatingView (1.0.3)
+  - JVFloatLabeledTextField (1.0.2)
+  - SHSPhoneComponent (2.15)
+  - XLDataLoader (1.1.0):
+    - AFNetworking (~> 2.0)
+  - XLForm (2.2.0)
+
+DEPENDENCIES:
+  - AFNetworking (~> 2.0)
+  - AXRatingView (= 1.0.3)
+  - JVFloatLabeledTextField (= 1.0.2)
+  - SHSPhoneComponent
+  - XLDataLoader (~> 1.1)
+  - XLForm (from `../../`)
+
+EXTERNAL SOURCES:
+  XLForm:
+    :path: ../../
+
+SPEC CHECKSUMS:
+  AFNetworking: fefbce9660acb17f48ae0011292d4da0f457bf36
+  AXRatingView: ccaadc1bbda99a4b7e1d556059482d2b933a9f4e
+  JVFloatLabeledTextField: 58a3a32cfb800e5b224f676987e7c13abf50a14d
+  SHSPhoneComponent: 4cec0653a150ad63cbc52b0c8b29ce2d3c9c26f0
+  XLDataLoader: 7d466e086f4b6ecd144e880be8232adbe80aef52
+  XLForm: 799e61ef230f519914e722bf032b19a597223c19
+
+COCOAPODS: 0.36.3

--- a/Examples/Objective-C/XLForm.xcodeproj/project.pbxproj
+++ b/Examples/Objective-C/XLForm.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		BFE91AFB1AE159B200DE5231 /* BasicPredicateViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = BFE91AFA1AE159B200DE5231 /* BasicPredicateViewController.m */; };
 		D51B8B2C19126664008C0478 /* XLFormCustomCell.m in Sources */ = {isa = PBXBuildFile; fileRef = D51B8B2B19126664008C0478 /* XLFormCustomCell.m */; };
 		DEA6EF911B57D6CC000F4893 /* HTTPSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = DEA6EF901B57D6CC000F4893 /* HTTPSessionManager.m */; };
+		DEB8235C1AD5529A00AF9FE2 /* FormattersViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = DEB8235B1AD5529A00AF9FE2 /* FormattersViewController.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -128,6 +129,9 @@
 		D51B8B2B19126664008C0478 /* XLFormCustomCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XLFormCustomCell.m; path = Examples/Others/CustomCells/XLFormCustomCell.m; sourceTree = "<group>"; };
 		DEA6EF8F1B57D6CC000F4893 /* HTTPSessionManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = HTTPSessionManager.h; path = Examples/Selectors/HTTPSessionManager.h; sourceTree = "<group>"; };
 		DEA6EF901B57D6CC000F4893 /* HTTPSessionManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = HTTPSessionManager.m; path = Examples/Selectors/HTTPSessionManager.m; sourceTree = "<group>"; };
+		DEB8235A1AD5529A00AF9FE2 /* FormattersViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FormattersViewController.h; sourceTree = "<group>"; };
+		DEB8235B1AD5529A00AF9FE2 /* FormattersViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FormattersViewController.m; sourceTree = "<group>"; };
+		F6DF43B7BBF44F72A4493E8E /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -312,6 +316,7 @@
 				282EB2791AB5FD66004A736F /* AccessoryViews */,
 				3CDAFC741AB0AEE5000F75B6 /* CustomRows */,
 				28F89F2B1AA4E99500E90218 /* Validations */,
+				DEB823591AD5529A00AF9FE2 /* Formatters */,
 				283C6B7A1999BA1B00A5283D /* UICustomization */,
 				28A76624193251E500D69546 /* AppDelegate.m */,
 				28A8083C190D903D009D77F8 /* StoryboardExample */,
@@ -461,6 +466,16 @@
 			name = SessionManager;
 			sourceTree = "<group>";
 		};
+		DEB823591AD5529A00AF9FE2 /* Formatters */ = {
+			isa = PBXGroup;
+			children = (
+				DEB8235A1AD5529A00AF9FE2 /* FormattersViewController.h */,
+				DEB8235B1AD5529A00AF9FE2 /* FormattersViewController.m */,
+			);
+			name = Formatters;
+			path = Examples/Formatters;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -606,6 +621,7 @@
 				BF01E9281C21F0BB00BDE045 /* XLFormInlineSegmentedCell.m in Sources */,
 				BF9DB1D61AE0436600B985E7 /* PredicateFormViewController.m in Sources */,
 				BFE91AFB1AE159B200DE5231 /* BasicPredicateViewController.m in Sources */,
+				DEB8235C1AD5529A00AF9FE2 /* FormattersViewController.m in Sources */,
 				2843EB5218D4CFC700F13E2B /* OthersFormViewController.m in Sources */,
 				2843EB4B18D496F600F13E2B /* SelectorsFormViewController.m in Sources */,
 				28468EA418EF41D300DBB015 /* InputsFormViewController.m in Sources */,

--- a/XLForm/XL/Cell/XLFormTextFieldCell.m
+++ b/XLForm/XL/Cell/XLFormTextFieldCell.m
@@ -147,7 +147,7 @@ NSString *const XLFormTextFieldLengthPercentage = @"textFieldLengthPercentage";
 
     self.textLabel.text = ((self.rowDescriptor.required && self.rowDescriptor.title && self.rowDescriptor.sectionDescriptor.formDescriptor.addAsteriskToRequiredRowsTitle) ? [NSString stringWithFormat:@"%@*", self.rowDescriptor.title] : self.rowDescriptor.title);
 
-    self.textField.text = self.rowDescriptor.value ? [self.rowDescriptor.value displayText] : self.rowDescriptor.noValueDisplayText;
+    self.textField.text = self.rowDescriptor.value ? [self.rowDescriptor displayTextValue] : self.rowDescriptor.noValueDisplayText;
     [self.textField setEnabled:!self.rowDescriptor.isDisabled];
     self.textField.textColor = self.rowDescriptor.isDisabled ? [UIColor grayColor] : [UIColor blackColor];
     self.textField.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
@@ -279,11 +279,22 @@ NSString *const XLFormTextFieldLengthPercentage = @"textFieldLengthPercentage";
 {
     [self.formViewController beginEditing:self.rowDescriptor];
     [self.formViewController textFieldDidBeginEditing:textField];
+    // set the input to the raw value if we have a formatter and it shouldn't be used during input
+    if (self.rowDescriptor.valueFormatter) {
+        self.textField.text = [self.rowDescriptor editTextValue];
+    }
 }
 
 - (void)textFieldDidEndEditing:(UITextField *)textField
 {
+    // process text change before we stick a formatted value in the UITextField
     [self textFieldDidChange:textField];
+    
+    // losing input, replace the text field with the formatted value
+    if (self.rowDescriptor.valueFormatter) {
+        self.textField.text = [self.rowDescriptor.value displayText];
+    }
+    
     [self.formViewController endEditing:self.rowDescriptor];
     [self.formViewController textFieldDidEndEditing:textField];
 }
@@ -293,12 +304,33 @@ NSString *const XLFormTextFieldLengthPercentage = @"textFieldLengthPercentage";
 
 - (void)textFieldDidChange:(UITextField *)textField{
     if([self.textField.text length] > 0) {
-        if ([self.rowDescriptor.rowType isEqualToString:XLFormRowDescriptorTypeNumber] || [self.rowDescriptor.rowType isEqualToString:XLFormRowDescriptorTypeDecimal]){
-            self.rowDescriptor.value =  @([self.textField.text doubleValue]);
-        } else if ([self.rowDescriptor.rowType isEqualToString:XLFormRowDescriptorTypeInteger]){
-            self.rowDescriptor.value = @([self.textField.text integerValue]);
-        } else {
-            self.rowDescriptor.value = self.textField.text;
+        BOOL didUseFormatter = NO;
+        
+        if (self.rowDescriptor.valueFormatter && self.rowDescriptor.useValueFormatterDuringInput)
+        {
+            // use generic getObjectValue:forString:errorDescription and stringForObjectValue
+            NSString *errorDescription = nil;
+            NSString *objectValue = nil;
+            
+            if ([ self.rowDescriptor.valueFormatter getObjectValue:&objectValue forString:textField.text errorDescription:&errorDescription]) {
+                NSString *formattedValue = [self.rowDescriptor.valueFormatter stringForObjectValue:objectValue];
+                
+                self.rowDescriptor.value = objectValue;
+                textField.text = formattedValue;
+                didUseFormatter = YES;
+            }
+        }
+        
+        // only do this conversion if we didn't use the formatter
+        if (!didUseFormatter)
+        {
+            if ([self.rowDescriptor.rowType isEqualToString:XLFormRowDescriptorTypeNumber] || [self.rowDescriptor.rowType isEqualToString:XLFormRowDescriptorTypeDecimal]){
+                self.rowDescriptor.value =  @([self.textField.text doubleValue]);
+            } else if ([self.rowDescriptor.rowType isEqualToString:XLFormRowDescriptorTypeInteger]){
+                self.rowDescriptor.value = @([self.textField.text integerValue]);
+            } else {
+                self.rowDescriptor.value = self.textField.text;
+            }
         }
     } else {
         self.rowDescriptor.value = nil;

--- a/XLForm/XL/Descriptors/XLFormRowDescriptor.h
+++ b/XLForm/XL/Descriptors/XLFormRowDescriptor.h
@@ -54,6 +54,14 @@ typedef void(^XLOnChangeBlock)(id __nullable oldValue,id __nullable newValue,XLF
 @property UITableViewCellStyle cellStyle;
 
 @property (copy, nullable) XLOnChangeBlock onChangeBlock;
+@property BOOL useValueFormatterDuringInput;
+@property (nullable) NSFormatter *valueFormatter;
+
+// returns the display text for the row descriptor, taking into account NSFormatters and default placeholder values
+- (nonnull NSString *) displayTextValue;
+
+// returns the editing text value for the row descriptor, taking into account NSFormatters.
+- (nonnull NSString *) editTextValue;
 
 @property (nonatomic, readonly, nonnull) NSMutableDictionary * cellConfig;
 @property (nonatomic, readonly, nonnull) NSMutableDictionary * cellConfigIfDisabled;

--- a/XLForm/XL/Descriptors/XLFormRowDescriptor.m
+++ b/XLForm/XL/Descriptors/XLFormRowDescriptor.m
@@ -44,6 +44,8 @@
 
 @end
 
+#import "NSObject+XLFormAdditions.h"
+
 @interface XLFormRowDescriptor() <NSCopying>
 
 @property XLFormBaseCell * cell;
@@ -170,6 +172,41 @@
     if (_cellConfigAtConfigure) return _cellConfigAtConfigure;
     _cellConfigAtConfigure = [NSMutableDictionary dictionary];
     return _cellConfigAtConfigure;
+}
+
+-(NSString*)editTextValue
+{
+    if (self.value) {
+        if (self.valueFormatter) {
+            if (self.useValueFormatterDuringInput) {
+                return [self displayTextValue];
+            }else{
+                // have formatter, but we don't want to use it during editing
+                return [self.value displayText];
+            }
+        }else{
+            // have value, but no formatter, use the value's displayText
+            return [self.value displayText];
+        }
+    }else{
+        // placeholder
+        return @"";
+    }
+}
+
+-(NSString*)displayTextValue
+{
+    if (self.value) {
+        if (self.valueFormatter) {
+            return [self.valueFormatter stringForObjectValue:self.value];
+        }
+        else{
+            return [self.value displayText];
+        }
+    }
+    else {
+        return self.noValueDisplayText;
+    }
 }
 
 -(NSString *)description


### PR DESCRIPTION
All the credits for this pull request are for @bhirt-bpl who made the initial PR https://github.com/xmartlabs/XLForm/pull/77 and also to @fwhenin who made an attempt https://github.com/xmartlabs/XLForm/pull/195 to rebase it 4 months ago.

I rebased all the work from @bhirt-bpl at current master and also removed the extra commits/features @fwhenin added on his PR.

* Added formatter related properties and methods to XLFormRowDescriptor
* Updated XLFormTextFieldCell to use formatters when specified.
* Created example page for formatters, FormattersViewController, and linked from OthersFormViewController
* Added SHSPhoneComponent to Podfile to demonstrate a phone formatter on FormattersViewController.

It will be nice if you could accept this Pull Request soon. Thanks