### PR TITLE
Add custom module map (requires CocoaPods 0.37)

### DIFF
--- a/XLForm.modulemap
+++ b/XLForm.modulemap
@@ -1,0 +1,6 @@
+framework module XLForm [system] {
+  umbrella header "XLForm.h"
+
+  export *
+  module * { export * }
+}

--- a/XLForm.podspec
+++ b/XLForm.podspec
@@ -10,6 +10,7 @@ Pod::Spec.new do |s|
   s.authors  = { 'Martin Barreto' => 'martin@xmartlabs.com' }
   s.source   = { :git => 'https://github.com/xmartlabs/XLForm.git', :tag => 'v3.0.0' }
   s.source_files = 'XLForm/XL/**/*.{h,m}'
+  s.module_map = 'XLForm.modulemap'
   s.requires_arc = true
   s.ios.deployment_target = '7.0'
   s.ios.frameworks = 'UIKit', 'Foundation', 'CoreGraphics'


### PR DESCRIPTION
Changes:
- Explicitly uses XLForm.h as the umbrella header (instead of the
  one generated by CocoaPods).
- Specifies the `[system]` attribute, so that warnings are suppressed when
  building the module.

A little bit of context on what prompted this change:
- We're using CocoaPods with dynamic frameworks on our project.
- We have the `-Wnewline-eof` warning enabled for our application target.
- When Xcode builds the XLForm module for our app target, a particular header with no newline at EOF causes that warning to be emitted, and there's nothing we can do to suppress it!
- Specifying a custom module map is useful because it means CocoaPods can use the existing umbrella header instead of generating one.
- Using the `[system]` attribute means that clients don't see warnings from XLForm headers.

Reference: http://clang.llvm.org/docs/Modules.html#module-declaration
