### PR TITLE
Use lastObject instead of objectAtIndex:0 in multivalued section for row template

### DIFF
--- a/XLForm/XL/Controllers/XLFormViewController.m
+++ b/XLForm/XL/Controllers/XLFormViewController.m
@@ -411,7 +411,7 @@
     if (formSection.multivaluedRowTemplate){
         return [formSection.multivaluedRowTemplate copy];
     }
-    XLFormRowDescriptor * formRowDescriptor = [[formSection.formRows objectAtIndex:0] copy];
+    XLFormRowDescriptor * formRowDescriptor = [[formSection.formRows lastObject] copy];
     formRowDescriptor.tag = nil;
     return formRowDescriptor;
 }


### PR DESCRIPTION
Be default use lastObject instead of objectAtIndex:0 in multivalued section as template for new rows. This is needed when you add values programmatically to a multivalued section. With objectAtIndex:0 the new row will contain the value of the first added row; which in normal circumstances works because you use a dummy row with a placeholder text. When adding rows programmatically based on predefined data this does not make sense.

It is possible avoid this using multivaluedRowTemplate on a form. The default behaviour is still nonsensical in my opinion.