### PR TITLE
Cells/Selectors: Added support for navigation controller selectors

### DIFF
--- a/XLForm/XL/Cell/XLFormSelectorCell.m
+++ b/XLForm/XL/Cell/XLFormSelectorCell.m
@@ -185,6 +185,9 @@
                 }
                 [controller.tableView deselectRowAtIndexPath:[controller.tableView indexPathForCell:self] animated:YES];
             }
+            else if ([selectorViewController isKindOfClass:[UINavigationController class]]) {
+                [controller presentViewController:selectorViewController animated:YES completion:nil];
+            }
             else {
                 [controller.navigationController pushViewController:selectorViewController animated:YES];
             }


### PR DESCRIPTION
Supporting pushing row descriptor action ViewControllers that are kind of UINavigationControllers.

Example:

```
row = [XLFormRowDescriptor formRowDescriptorWithTag:kFormPerson rowType:XLFormRowDescriptorTypeSelectorPush];
row.action.viewControllerClass = [PeoplePickerRowDescriptorViewController class];
```

where PeoplePickerRowDescriptorViewController is something like this

```
@interface PeoplePickerRowDescriptorViewController : ABPeoplePickerNavigationController<XLFormRowDescriptorViewController, ABPeoplePickerNavigationControllerDelegate>

@end
```
