### PR TITLE
title labels should be always visible

### DIFF
--- a/XLForm/XL/Cell/XLFormTextFieldCell.m
+++ b/XLForm/XL/Cell/XLFormTextFieldCell.m
@@ -181,6 +181,7 @@
 {
     NSMutableArray * result = [[NSMutableArray alloc] init];
     [self.textLabel setContentHuggingPriority:500 forAxis:UILayoutConstraintAxisHorizontal];    
+    [self.textLabel setContentCompressionResistancePriority:1000 forAxis:UILayoutConstraintAxisHorizontal];
     [result addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(>=11)-[_textField]-(>=11)-|" options:NSLayoutFormatAlignAllBaseline metrics:nil views:NSDictionaryOfVariableBindings(_textField)]];
     
     [result addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(>=11)-[_textLabel]-(>=11)-|" options:NSLayoutFormatAlignAllBaseline metrics:nil views:NSDictionaryOfVariableBindings(_textLabel)]];


### PR DESCRIPTION
When the user enters long texts in the `XLFormTextFieldCell` and the form is reloaded, the title label width becomes 0. My bugfix prevents the title label to get compressed.

Issue:
![issue](https://cloud.githubusercontent.com/assets/513312/8203400/7be7833a-14d9-11e5-976f-5abeea7dec11.png)
Bugfix:
![bugfix](https://cloud.githubusercontent.com/assets/513312/8203401/7bedb642-14d9-11e5-9df4-4d22f5a7a005.png)

 