### PR TITLE
Allow styling of XLFormOptionsViewController rows

### DIFF
--- a/XLForm/XL/Controllers/XLFormOptionsViewController.m
+++ b/XLForm/XL/Controllers/XLFormOptionsViewController.m
@@ -87,11 +87,9 @@
     XLFormRightDetailCell * cell = [tableView dequeueReusableCellWithIdentifier:CELL_REUSE_IDENTIFIER forIndexPath:indexPath];
     id cellObject =  [[self selectorOptions] objectAtIndex:indexPath.row];
 
-    if ([self.rowDescriptor cellConfigForSelector]) {
-        [self.rowDescriptor.cellConfigForSelector enumerateKeysAndObjectsUsingBlock:^(NSString *keyPath, id value, __unused BOOL *stop) {
-            [cell setValue:(value == [NSNull null]) ? nil : value forKeyPath:keyPath];
-        }];
-    }
+    [self.rowDescriptor.cellConfigForSelector enumerateKeysAndObjectsUsingBlock:^(NSString *keyPath, id value, __unused BOOL *stop) {
+        [cell setValue:(value == [NSNull null]) ? nil : value forKeyPath:keyPath];
+    }];
     
     cell.textLabel.text = [self valueDisplayTextForOption:cellObject];
     if ([self.rowDescriptor.rowType isEqualToString:XLFormRowDescriptorTypeMultipleSelector] || [self.rowDescriptor.rowType isEqualToString:XLFormRowDescriptorTypeMultipleSelectorPopover]){

--- a/XLForm/XL/Controllers/XLFormOptionsViewController.m
+++ b/XLForm/XL/Controllers/XLFormOptionsViewController.m
@@ -86,6 +86,13 @@
 {
     XLFormRightDetailCell * cell = [tableView dequeueReusableCellWithIdentifier:CELL_REUSE_IDENTIFIER forIndexPath:indexPath];
     id cellObject =  [[self selectorOptions] objectAtIndex:indexPath.row];
+
+    if ([self.rowDescriptor cellConfigForSelector]) {
+        [self.rowDescriptor.cellConfigForSelector enumerateKeysAndObjectsUsingBlock:^(NSString *keyPath, id value, __unused BOOL *stop) {
+            [cell setValue:(value == [NSNull null]) ? nil : value forKeyPath:keyPath];
+        }];
+    }
+    
     cell.textLabel.text = [self valueDisplayTextForOption:cellObject];
     if ([self.rowDescriptor.rowType isEqualToString:XLFormRowDescriptorTypeMultipleSelector] || [self.rowDescriptor.rowType isEqualToString:XLFormRowDescriptorTypeMultipleSelectorPopover]){
         cell.accessoryType = ([self selectedValuesContainsOption:cellObject] ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone);

--- a/XLForm/XL/Descriptors/XLFormRowDescriptor.h
+++ b/XLForm/XL/Descriptors/XLFormRowDescriptor.h
@@ -52,6 +52,7 @@ typedef NS_ENUM(NSUInteger, XLFormPresentationMode) {
 @property UITableViewCellStyle cellStyle;
 
 @property (nonatomic) NSMutableDictionary *cellConfig;
+@property (nonatomic) NSMutableDictionary *cellConfigForSelector;
 @property (nonatomic) NSMutableDictionary *cellConfigIfDisabled;
 @property (nonatomic) NSMutableDictionary *cellConfigAtConfigure;
 

--- a/XLForm/XL/Descriptors/XLFormRowDescriptor.m
+++ b/XLForm/XL/Descriptors/XLFormRowDescriptor.m
@@ -138,6 +138,14 @@
     return _cellConfig;
 }
 
+-(NSMutableDictionary *)cellConfigForSelector
+{
+    if (_cellConfigForSelector) return _cellConfigForSelector;
+    _cellConfigForSelector = [NSMutableDictionary dictionary];
+    return _cellConfigForSelector;
+}
+
+
 -(NSMutableDictionary *)cellConfigIfDisabled
 {
     if (_cellConfigIfDisabled) return _cellConfigIfDisabled;


### PR DESCRIPTION
The cellConfig property of a RowDescriptor allows you to style a cell to change fonts, colors, etc. But, if that row is a type that pushes the XLFormOptionsViewController, the cells that show up for the selection are not styled at all.  If you're styling fonts, this pretty much looks like crap.

Added a dictionary called "cellConfigForSelector" that the XLFormOptionsViewController uses to style its rows.