### PR TITLE
labels cannot squish textFields anymore

### DIFF
--- a/XLForm/XL/Cell/XLFormTextFieldCell.m
+++ b/XLForm/XL/Cell/XLFormTextFieldCell.m
@@ -76,6 +76,7 @@
 -(void)update
 {
     [super update];
+	self.textLabel.numberOfLines = 0;
     self.textField.delegate = self;
     self.textField.clearButtonMode = UITextFieldViewModeWhileEditing;
     if ([self.rowDescriptor.rowType isEqualToString:XLFormRowDescriptorTypeText]){
@@ -182,9 +183,9 @@
     NSMutableArray * result = [[NSMutableArray alloc] init];
     [self.textLabel setContentHuggingPriority:500 forAxis:UILayoutConstraintAxisHorizontal];    
     [self.textLabel setContentCompressionResistancePriority:1000 forAxis:UILayoutConstraintAxisHorizontal];
-    [result addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(>=11)-[_textField]-(>=11)-|" options:NSLayoutFormatAlignAllBaseline metrics:nil views:NSDictionaryOfVariableBindings(_textField)]];
+    [result addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(11)-[_textField]-(11)-|" options:NSLayoutFormatAlignAllBaseline metrics:nil views:NSDictionaryOfVariableBindings(_textField)]];
     
-    [result addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(>=11)-[_textLabel]-(>=11)-|" options:NSLayoutFormatAlignAllBaseline metrics:nil views:NSDictionaryOfVariableBindings(_textLabel)]];
+    [result addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(11)-[_textLabel]-(11)-|" options:NSLayoutFormatAlignAllBaseline metrics:nil views:NSDictionaryOfVariableBindings(_textLabel)]];
     return result;
 }
 
@@ -213,6 +214,18 @@
         }
     }
     [self.contentView addConstraints:self.dynamicCustomConstraints];
+
+	// make the textField min. 1/3 of the screen's width. Otherwise input will be impossible
+	self.dynamicCustomConstraints = @[[NSLayoutConstraint constraintWithItem:self.textField
+																																 attribute:NSLayoutAttributeWidth
+																																 relatedBy:NSLayoutRelationGreaterThanOrEqual
+																																		toItem:self.contentView
+																																 attribute:NSLayoutAttributeWidth
+																																multiplier:.3
+																																	constant:0.0]];
+	[self.contentView addConstraints:self.dynamicCustomConstraints];
+
+	
     [super updateConstraints];
 }
 


### PR DESCRIPTION
made textFields within XLFormTextFieldCells a min. width of 1/3 screen width. That way very long labels cannot squeeze the textField until input becomes impossible. Also labels are multi-line now.