### PR TITLE
Remove setting the root VC in init

### DIFF
--- a/Examples/Objective-C/Examples/RealExamples/NativeEventFormViewController.m
+++ b/Examples/Objective-C/Examples/RealExamples/NativeEventFormViewController.m
@@ -30,12 +30,6 @@
 
 @implementation NativeEventNavigationViewController
 
--(id)init
-{
-    self = [super initWithRootViewController:[[NativeEventFormViewController alloc] init]];
-    return  self;
-}
-
 -(void)viewDidLoad
 {
     [super viewDidLoad];


### PR DESCRIPTION
For the event example it is already set in the storyboard so it is not needed here.