### PR TITLE
Adds ability to specify a titleView on sections.

### DIFF
--- a/XLForm/XL/Controllers/XLFormViewController.m
+++ b/XLForm/XL/Controllers/XLFormViewController.m
@@ -704,6 +704,21 @@
     return [[self.form.formSections objectAtIndex:section] title];
 }
 
+- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
+{
+  return [[self.form.formSections objectAtIndex:section] titleView];
+}
+
+- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
+{
+  UIView * view = [[self.form.formSections objectAtIndex:section] titleView];
+  if(view){
+    return view.frame.size.height;
+  } else{
+    return 0.0f;
+  }
+}
+
 -(NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
 {
     return [[self.form.formSections objectAtIndex:section] footerTitle];

--- a/XLForm/XL/Descriptors/XLFormSectionDescriptor.h
+++ b/XLForm/XL/Descriptors/XLFormSectionDescriptor.h
@@ -43,6 +43,7 @@ typedef NS_ENUM(NSUInteger, XLFormSectionInsertMode) {
 @interface XLFormSectionDescriptor : NSObject
 
 @property (nonatomic, nullable) NSString * title;
+@property (nonatomic, nullable) UIView * titleView;
 @property (nonatomic, nullable) NSString * footerTitle;
 @property (readonly, nonnull) NSMutableArray * formRows;
 

--- a/XLForm/XL/Descriptors/XLFormSectionDescriptor.m
+++ b/XLForm/XL/Descriptors/XLFormSectionDescriptor.m
@@ -67,6 +67,7 @@
         _sectionInsertMode = XLFormSectionInsertModeLastRow;
         _sectionOptions = XLFormSectionOptionNone;
         _title = nil;
+        _titleView = nil;
         _footerTitle = nil;
         _hidden = @NO;
         _hidePredicateCache = @NO;
@@ -82,6 +83,7 @@
         _sectionInsertMode = sectionInsertMode;
         _sectionOptions = sectionOptions;
         _title = title;
+        _titleView = nil;
         if ([self canInsertUsingButton]){
             _multivaluedAddButton = [XLFormRowDescriptor formRowDescriptorWithTag:nil rowType:XLFormRowDescriptorTypeButton title:@"Add Item"];
             [_multivaluedAddButton.cellConfig setObject:@(NSTextAlignmentLeft) forKey:@"textLabel.textAlignment"];


### PR DESCRIPTION
Example usage:

```obj-c
section = [XLFormSectionDescriptor formSectionWithTitle:@"Real examples"];
section.titleView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 320, 50)]
// Basically anything that's a subclass of UIView
```

The UITableViewDelegate will fall back to using `-(NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)` if the `titleView` is `nil`.
