### PR TITLE
Readded designated initializer of XLFormDescriptor to header file.

### DIFF
--- a/XLForm/XL/Descriptors/XLFormDescriptor.h
+++ b/XLForm/XL/Descriptors/XLFormDescriptor.h
@@ -58,6 +58,7 @@ typedef NS_OPTIONS(NSUInteger, XLFormRowNavigationOptions) {
 
 @property (weak, nullable) id<XLFormDescriptorDelegate> delegate;
 
+-(nonnull instancetype)initWithTitle:(nullable NSString *)title;
 +(nonnull instancetype)formDescriptor;
 +(nonnull instancetype)formDescriptorWithTitle:(nullable NSString *)title;
 


### PR DESCRIPTION
Not sure why it has been removed, but I need it for subclassing XLFormDescriptor.