### PR TITLE
Add zipCode to XLFormRowDescriptorType's

### DIFF
--- a/Examples/Objective-C/Examples/Inputs/InputsFormViewController.m
+++ b/Examples/Objective-C/Examples/Inputs/InputsFormViewController.m
@@ -30,6 +30,7 @@
 NSString *const kName = @"name";
 NSString *const kEmail = @"email";
 NSString *const kTwitter = @"twitter";
+NSString *const kZipCode = @"zipCode";
 NSString *const kNumber = @"number";
 NSString *const kInteger = @"integer";
 NSString *const kDecimal = @"decimal";
@@ -72,6 +73,10 @@ NSString *const kNotes = @"notes";
     row.value = @"@no_editable";
     [section addFormRow:row];
     
+    // Zip Code
+    row = [XLFormRowDescriptor formRowDescriptorWithTag:kZipCode rowType:XLFormRowDescriptorTypeZipCode title:@"Zip Code"];
+    [section addFormRow:row];
+
     // Number
     row = [XLFormRowDescriptor formRowDescriptorWithTag:kNumber rowType:XLFormRowDescriptorTypeNumber title:@"Number"];
     [section addFormRow:row];

--- a/Examples/Swift/Examples/Inputs/InputsFormViewController.swift
+++ b/Examples/Swift/Examples/Inputs/InputsFormViewController.swift
@@ -37,6 +37,7 @@ class InputsFormViewController : XLFormViewController {
         case Password = "password"
         case Phone = "phone"
         case Url = "url"
+        case ZipCode = "zipCode"
         case TextView = "textView"
         case Notes = "notes"
     }
@@ -82,6 +83,10 @@ class InputsFormViewController : XLFormViewController {
         row.value = "@no_editable"
         section.addFormRow(row)
         
+        // Zip Code
+        row = XLFormRowDescriptor(tag: Tags.ZipCode.rawValue, rowType: XLFormRowDescriptorTypeZipCode, title: "Zip Code")
+        section.addFormRow(row)
+
         // Number
         row = XLFormRowDescriptor(tag: Tags.Number.rawValue, rowType: XLFormRowDescriptorTypeNumber, title: "Number")
         section.addFormRow(row)

--- a/XLForm/XL/Cell/XLFormTextFieldCell.m
+++ b/XLForm/XL/Cell/XLFormTextFieldCell.m
@@ -130,9 +130,14 @@ NSString *const XLFormTextFieldLengthPercentage = @"textFieldLengthPercentage";
         self.textField.autocorrectionType = UITextAutocorrectionTypeNo;
         self.textField.autocapitalizationType = UITextAutocapitalizationTypeNone;
     }
-    
+    else if ([self.rowDescriptor.rowType isEqualToString:XLFormRowDescriptorTypeZipCode]){
+        self.textField.autocorrectionType = UITextAutocorrectionTypeNo;
+        self.textField.autocapitalizationType = UITextAutocapitalizationTypeAllCharacters;
+        self.textField.keyboardType = UIKeyboardTypeDefault;
+    }
+
     self.textLabel.text = ((self.rowDescriptor.required && self.rowDescriptor.title && self.rowDescriptor.sectionDescriptor.formDescriptor.addAsteriskToRequiredRowsTitle) ? [NSString stringWithFormat:@"%@*", self.rowDescriptor.title] : self.rowDescriptor.title);
-    
+
     self.textField.text = self.rowDescriptor.value ? [self.rowDescriptor.value displayText] : self.rowDescriptor.noValueDisplayText;
     [self.textField setEnabled:!self.rowDescriptor.isDisabled];
     self.textField.textColor = self.rowDescriptor.isDisabled ? [UIColor grayColor] : [UIColor blackColor];
@@ -182,13 +187,13 @@ NSString *const XLFormTextFieldLengthPercentage = @"textFieldLengthPercentage";
 -(NSArray *)layoutConstraints
 {
     NSMutableArray * result = [[NSMutableArray alloc] init];
-    [self.textLabel setContentHuggingPriority:500 forAxis:UILayoutConstraintAxisHorizontal];    
+    [self.textLabel setContentHuggingPriority:500 forAxis:UILayoutConstraintAxisHorizontal];
     [self.textLabel setContentCompressionResistancePriority:1000 forAxis:UILayoutConstraintAxisHorizontal];
-    
+
     // Add Constraints
     [result addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(>=11)-[_textField]-(>=11)-|" options:NSLayoutFormatAlignAllBaseline metrics:nil views:NSDictionaryOfVariableBindings(_textField)]];
     [result addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(>=11)-[_textLabel]-(>=11)-|" options:NSLayoutFormatAlignAllBaseline metrics:nil views:NSDictionaryOfVariableBindings(_textLabel)]];
-    
+
     return result;
 }
 
@@ -216,7 +221,7 @@ NSString *const XLFormTextFieldLengthPercentage = @"textFieldLengthPercentage";
             self.dynamicCustomConstraints = [NSMutableArray arrayWithArray:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-(leftMargin)-[textField]-(rightMargin)-|" options:0 metrics:metrics views:views]];
         }
     }
-    
+
     [self.dynamicCustomConstraints addObject:[NSLayoutConstraint constraintWithItem:_textField
                                                                           attribute:NSLayoutAttributeWidth
                                                                           relatedBy:self.textFieldLengthPercentage ? NSLayoutRelationEqual : NSLayoutRelationGreaterThanOrEqual
@@ -224,7 +229,7 @@ NSString *const XLFormTextFieldLengthPercentage = @"textFieldLengthPercentage";
                                                                           attribute:NSLayoutAttributeWidth
                                                                          multiplier:self.textFieldLengthPercentage ? [self.textFieldLengthPercentage floatValue] : 0.3
                                                                            constant:0.0]];
-    
+
     [self.contentView addConstraints:self.dynamicCustomConstraints];
     [super updateConstraints];
 }

--- a/XLForm/XL/Controllers/XLFormViewController.m
+++ b/XLForm/XL/Controllers/XLFormViewController.m
@@ -162,7 +162,7 @@
                                              selector:@selector(keyboardWillShow:)
                                                  name:UIKeyboardWillShowNotification
                                                object:nil];
-    
+
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(keyboardWillHide:)
                                                  name:UIKeyboardWillHideNotification
@@ -203,7 +203,7 @@
 +(NSMutableDictionary *)cellClassesForRowDescriptorTypes
 {
     static NSMutableDictionary * _cellClassesForRowDescriptorTypes;
-    
+
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         _cellClassesForRowDescriptorTypes = [@{XLFormRowDescriptorTypeText:[XLFormTextFieldCell class],
@@ -217,6 +217,7 @@
                                                XLFormRowDescriptorTypeNumber: [XLFormTextFieldCell class],
                                                XLFormRowDescriptorTypeInteger: [XLFormTextFieldCell class],
                                                XLFormRowDescriptorTypeDecimal: [XLFormTextFieldCell class],
+                                               XLFormRowDescriptorTypeZipCode: [XLFormTextFieldCell class],
                                                XLFormRowDescriptorTypeSelectorPush: [XLFormSelectorCell class],
                                                XLFormRowDescriptorTypeSelectorPopover: [XLFormSelectorCell class],
                                                XLFormRowDescriptorTypeSelectorActionSheet: [XLFormSelectorCell class],
@@ -254,7 +255,7 @@
 +(NSMutableDictionary *)inlineRowDescriptorTypesForRowDescriptorTypes
 {
     static NSMutableDictionary * _inlineRowDescriptorTypesForRowDescriptorTypes;
-    
+
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         _inlineRowDescriptorTypesForRowDescriptorTypes = [
@@ -652,7 +653,7 @@
         self.tableView.editing = !self.tableView.editing;
         self.tableView.editing = !self.tableView.editing;
     });
-    
+
 }
 
 -(void)tableView:(UITableView *)tableView commitEditingStyle:(UITableViewCellEditingStyle)editingStyle forRowAtIndexPath:(NSIndexPath *)indexPath
@@ -787,7 +788,7 @@
             return [NSIndexPath indexPathForRow:proposedDestinationIndexPath.row - 1 inSection:sourceIndexPath.section];
         }
     }
-    
+
     if ((sectionDescriptor.sectionInsertMode == XLFormSectionInsertModeButton && sectionDescriptor.sectionOptions & XLFormSectionOptionCanInsert)){
         if (proposedDestinationIndexPath.row == sectionDescriptor.formRows.count - 1){
             return [NSIndexPath indexPathForRow:(sectionDescriptor.formRows.count - 2) inSection:sourceIndexPath.section];

--- a/XLForm/XL/XLForm.h
+++ b/XLForm/XL/XLForm.h
@@ -79,6 +79,7 @@ extern NSString *const XLFormRowDescriptorTypeAccount;
 extern NSString *const XLFormRowDescriptorTypeInteger;
 extern NSString *const XLFormRowDescriptorTypeDecimal;
 extern NSString *const XLFormRowDescriptorTypeTextView;
+extern NSString *const XLFormRowDescriptorTypeZipCode;
 extern NSString *const XLFormRowDescriptorTypeSelectorPush;
 extern NSString *const XLFormRowDescriptorTypeSelectorPopover;
 extern NSString *const XLFormRowDescriptorTypeSelectorActionSheet;

--- a/XLForm/XL/XLForm.m
+++ b/XLForm/XL/XLForm.m
@@ -38,6 +38,7 @@ NSString *const XLFormRowDescriptorTypeAccount = @"account";
 NSString *const XLFormRowDescriptorTypeInteger = @"integer";
 NSString *const XLFormRowDescriptorTypeDecimal = @"decimal";
 NSString *const XLFormRowDescriptorTypeTextView = @"textView";
+NSString *const XLFormRowDescriptorTypeZipCode = @"zipCode";
 NSString *const XLFormRowDescriptorTypeSelectorPush = @"selectorPush";
 NSString *const XLFormRowDescriptorTypeSelectorPopover = @"selectorPopover";
 NSString *const XLFormRowDescriptorTypeSelectorActionSheet = @"selectorActionSheet";


### PR DESCRIPTION
This adds a new type of XLFormRowDescriptor, of type ZipCode.

This type (as can be seen in the diff) is just like a regular textInput however it has auto-correct disabled and auto-capitalization set to all characters.

The reason for adding this is that when inputting things like zip codes and postal codes auto correct gets confused and having all characters in caps is usually the desired pattern.

Examples have been added to both the Objective-C and the Swift example projects.