### PR TITLE
Ability to notify about option selection

### DIFF
--- a/XLForm/XL/Controllers/XLFormOptionsViewController.h
+++ b/XLForm/XL/Controllers/XLFormOptionsViewController.h
@@ -30,6 +30,8 @@
 
 @interface XLFormOptionsViewController : UITableViewController<XLFormRowDescriptorViewController, XLFormRowDescriptorPopoverViewController>
 
+@property (nonatomic, copy) void (^didSelectedOption)(id option);
+
 - (id)initWithStyle:(UITableViewStyle)style;
 
 

--- a/XLForm/XL/Controllers/XLFormOptionsViewController.m
+++ b/XLForm/XL/Controllers/XLFormOptionsViewController.m
@@ -156,6 +156,9 @@
             [self.navigationController popViewControllerAnimated:YES];
         }
     }
+    if (self.didSelectedOption != nil) {
+        self.didSelectedOption(cellObject);
+    }
     [self.tableView deselectRowAtIndexPath:indexPath animated:YES];
 }
 


### PR DESCRIPTION
Very useful when developing custom rows, so I can just, for example:
```Objective-C
    XLFormOptionsViewController * optionsViewController = [[XLFormOptionsViewController alloc]  initWithStyle:UITableViewStyleGrouped];
    optionsViewController.title = @"Variants";
    optionsViewController.rowDescriptor = self.rowDescriptor;
    [self.formViewController.navigationController pushViewController:optionsViewController animated:YES];
    __weak typeof(self) weakself = self;
    optionsViewController.didSelectedOption = ^(id option) {
        weakself.rowDescriptor.value = option;
        [weakself update];
    };
```
What you think? :wink: 