### PR TITLE
fix bug 553

### DIFF
--- a/XLForm/XL/Cell/XLFormInlineSelectorCell.m
+++ b/XLForm/XL/Cell/XLFormInlineSelectorCell.m
@@ -66,7 +66,9 @@
     XLFormRowDescriptor * nextFormRow = [self.formViewController.form formRowAtIndex:nextRowPath];
     XLFormSectionDescriptor * formSection = [self.formViewController.form.formSections objectAtIndex:nextRowPath.section];
     BOOL result = [super resignFirstResponder];
-    [formSection removeFormRow:nextFormRow];
+    if (result) {
+        [formSection removeFormRow:nextFormRow];
+    }
     return result;
 }
 


### PR DESCRIPTION
Setting row of type XLFormRowDescriptorTypeSelectorPickerViewInline to disabled removes the next row from the form