### PR TITLE
Change XLFormDateCell to call update when value changes

### DIFF
--- a/XLForm/XL/Cell/XLFormDateCell.m
+++ b/XLForm/XL/Cell/XLFormDateCell.m
@@ -227,7 +227,7 @@
 - (void)datePickerValueChanged:(UIDatePicker *)sender
 {
     self.rowDescriptor.value = sender.date;
-    self.detailTextLabel.text = [self valueDisplayText];
+    [self update];
     [self setNeedsLayout];
     
 }


### PR DESCRIPTION
@mats-claassen Hi there, I've been trying to use my own subclass of XLFormDateCell with a custom UI but update doesn't seem to be called when the form changes its value. This pull request changes that so that it can be subclassed and customized appropriately. Let me know if I'm missing anything here! Thanks! 