### PR TITLE
Improved XLFormOptionsViewController customization support

### DIFF
--- a/XLForm/XL/Controllers/XLFormViewController.m
+++ b/XLForm/XL/Controllers/XLFormViewController.m
@@ -120,8 +120,7 @@
         self.tableView = [[UITableView alloc] initWithFrame:self.view.bounds
                                                       style:self.tableViewStyle];
         self.tableView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-    }
-    if (!self.tableView.superview){
+
         [self.view addSubview:self.tableView];
     }
     if (!self.tableView.delegate){

--- a/XLForm/XL/Descriptors/XLFormRowDescriptor.h
+++ b/XLForm/XL/Descriptors/XLFormRowDescriptor.h
@@ -122,12 +122,16 @@ typedef void(^XLOnChangeBlock)(id __nullable oldValue,id __nullable newValue,XLF
 @end
 
 
-@protocol XLFormOptionObject
+@protocol XLFormOptionObject <NSObject>
 
-@required
+@property (nonatomic, readonly, nonnull) NSString *formDisplayText;
+@property (nonatomic, readonly, nonnull) id formValue;
 
--(nonnull NSString *)formDisplayText;
--(nonnull id)formValue;
+@optional
+
+-(void)configureCell:(nonnull id)optionCell;
+
+@property (nonatomic, readonly, nonnull) NSString *cellReuseIdentifier;
 
 @end
 


### PR DESCRIPTION
I needed to display images in options cells. So I extended XLFormOptionObject with an optional method `configureCell:`. By implementing this method objects can perform extra customization on a cell provided.

I also added `cellReuseIdentifier ` optional property, which allows the option to be displayed by a custom cell.