### PR TITLE
Fix Table view not pinned to top layout guide #561

### DIFF
--- a/XLForm/XL/Controllers/XLFormViewController.m
+++ b/XLForm/XL/Controllers/XLFormViewController.m
@@ -193,6 +193,14 @@
     }
 }
 
+- (void)viewDidLayoutSubviews
+{
+    [super viewDidLayoutSubviews];
+    UIEdgeInsets insets = self.tableView.contentInset;
+    insets.top = self.topLayoutGuide.length;
+    self.tableView.contentInset = insets;
+}
+
 - (void)didReceiveMemoryWarning
 {
     [super didReceiveMemoryWarning];


### PR DESCRIPTION
Fixes issue #561 where the table view contents are underneath the nav bar on iOS 9:

![simulator screen shot sep 16 2015 4 41 09 pm](https://cloud.githubusercontent.com/assets/518687/9921387/c68dac70-5c91-11e5-8b6c-e4ebcf5ba80c.png)
