### PR TITLE
Fix Ipad layout on iOS 9.0

### DIFF
--- a/XLForm/XL/Controllers/XLFormViewController.m
+++ b/XLForm/XL/Controllers/XLFormViewController.m
@@ -134,10 +134,20 @@
         self.tableView.rowHeight = UITableViewAutomaticDimension;
         self.tableView.estimatedRowHeight = 44.0;
     }
-    if([self.tableView respondsToSelector:@selector(cellLayoutMarginsFollowReadableWidth)])
-    {
-        self.tableView.cellLayoutMarginsFollowReadableWidth = NO;
-    }
+// Temporary commented until Travis will be moved to Xcode 7.0 with iOS SDK 9.0
+//    if([self.tableView respondsToSelector:@selector(cellLayoutMarginsFollowReadableWidth)])
+//    {
+//        self.tableView.cellLayoutMarginsFollowReadableWidth = NO;
+//    }
+    NSMethodSignature* signature = [[self.tableView class] instanceMethodSignatureForSelector:@selector(setCellLayoutMarginsFollowReadableWidth:)];
+    NSInvocation* invocation = [NSInvocation invocationWithMethodSignature:signature];
+    [invocation setTarget:self.tableView];
+    [invocation setSelector:@selector(setCellLayoutMarginsFollowReadableWidth:)];
+
+    BOOL boolValue = NO;
+    [invocation setArgument:&boolValue atIndex: 2];
+    [invocation invoke];
+
     if (self.form.title){
         self.title = self.form.title;
     }

--- a/XLForm/XL/Controllers/XLFormViewController.m
+++ b/XLForm/XL/Controllers/XLFormViewController.m
@@ -134,7 +134,7 @@
         self.tableView.rowHeight = UITableViewAutomaticDimension;
         self.tableView.estimatedRowHeight = 44.0;
     }
-    if(SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"9.0"))
+    if([self.tableView respondsToSelector:@selector(cellLayoutMarginsFollowReadableWidth)])
     {
         self.tableView.cellLayoutMarginsFollowReadableWidth = NO;
     }

--- a/XLForm/XL/Controllers/XLFormViewController.m
+++ b/XLForm/XL/Controllers/XLFormViewController.m
@@ -134,6 +134,10 @@
         self.tableView.rowHeight = UITableViewAutomaticDimension;
         self.tableView.estimatedRowHeight = 44.0;
     }
+    if(SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"9.0"))
+    {
+        self.tableView.cellLayoutMarginsFollowReadableWidth = NO;
+    }
     if (self.form.title){
         self.title = self.form.title;
     }


### PR DESCRIPTION
Fix layout in both rotations, portrait and landscape 

Mentioned in these issues: #627 #554  

