### PR TITLE
prevent XLFormInlineSelectorCell from removing the row beneath when not first responder

### DIFF
--- a/XLForm/XL/Cell/XLFormInlineSelectorCell.m
+++ b/XLForm/XL/Cell/XLFormInlineSelectorCell.m
@@ -61,6 +61,9 @@
 
 -(BOOL)resignFirstResponder
 {
+    if (![self isFirstResponder]) {
+        return [super resignFirstResponder];
+    }
     NSIndexPath * selectedRowPath = [self.formViewController.form indexPathOfFormRow:self.rowDescriptor];
     NSIndexPath * nextRowPath = [NSIndexPath indexPathForRow:selectedRowPath.row + 1 inSection:selectedRowPath.section];
     XLFormRowDescriptor * nextFormRow = [self.formViewController.form formRowAtIndex:nextRowPath];


### PR DESCRIPTION
@mtnbarreto 

For the XLFormInlineSelector cell, a call to -resignFirstResponder removes the next row in the form.  If the cell is not the first responder it should not remove the next row of the form.  