### PR TITLE
Add XLFormRowDescriptorTypeImage

### DIFF
--- a/Examples/Objective-C/Examples/Others/OthersFormViewController.m
+++ b/Examples/Objective-C/Examples/Others/OthersFormViewController.m
@@ -34,6 +34,7 @@ NSString *const kSegmentedControl = @"segmentedControl";
 NSString *const kCustom = @"custom";
 NSString *const kInfo = @"info";
 NSString *const kButton = @"button";
+NSString *const kImage = @"image";
 NSString *const kButtonLeftAligned = @"buttonLeftAligned";
 NSString *const kButtonWithSegueId = @"buttonWithSegueId";
 NSString *const kButtonWithSegueClass = @"buttonWithSegueClass";
@@ -102,6 +103,10 @@ NSString *const kButtonWithStoryboardId = @"buttonWithStoryboardId";
     [row.cellConfigAtConfigure setObject:@(4) forKey:@"steps"];
     [section addFormRow:row];
     
+    // Image
+    row = [XLFormRowDescriptor formRowDescriptorWithTag:kImage rowType:XLFormRowDescriptorTypeImage title:@"Image"];
+    row.value = [UIImage imageNamed:@"default_avatar"];
+    [section addFormRow:row];
 
     // Info cell
     XLFormRowDescriptor *infoRowDescriptor = [XLFormRowDescriptor formRowDescriptorWithTag:kInfo rowType:XLFormRowDescriptorTypeInfo];

--- a/XLForm/XL/Cell/XLFormImageCell.h
+++ b/XLForm/XL/Cell/XLFormImageCell.h
@@ -1,0 +1,33 @@
+//
+//  XLFormBaseCell.h
+//  XLForm ( https://github.com/xmartlabs/XLForm )
+//
+//  Copyright (c) 2015 Xmartlabs ( http://xmartlabs.com )
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "XLFormBaseCell.h"
+
+@interface XLFormImageCell : XLFormBaseCell
+
+@end
+
+
+

--- a/XLForm/XL/Cell/XLFormImageCell.m
+++ b/XLForm/XL/Cell/XLFormImageCell.m
@@ -1,0 +1,145 @@
+//
+//  XLFormBaseCell.m
+//  XLForm ( https://github.com/xmartlabs/XLForm )
+//
+//  Copyright (c) 2015 Xmartlabs ( http://xmartlabs.com )
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "XLFormImageCell.h"
+#import "XLFormRowDescriptor.h"
+#import "UIView+XLFormAdditions.h"
+
+@interface XLFormImageCell() <UIImagePickerControllerDelegate, UINavigationControllerDelegate>
+{
+    UIPopoverController *popoverController;
+    UIImagePickerController *imagePickerController;
+    UIAlertController *alertController;
+}
+
+@end
+
+@implementation XLFormImageCell
+
+#pragma mark - XLFormDescriptorCell
++ (CGFloat)formDescriptorCellHeightForRowDescriptor:(XLFormRowDescriptor *)rowDescriptor
+{
+    return 40;
+}
+
+- (void)configure
+{
+    [super configure];
+    self.selectionStyle = UITableViewCellSelectionStyleNone;
+    self.accessoryView = [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, 30, 30)];
+    self.editingAccessoryView = self.accessoryView;
+}
+
+- (void)update
+{
+    [super update];
+    self.textLabel.text = self.rowDescriptor.title;
+    self.imageView.image = self.rowDescriptor.value;
+}
+
+- (void)chooseImage:(UIImage *)image
+{
+    self.imageView.image = image;
+    self.rowDescriptor.value = image;
+}
+
+- (UIImageView *)imageView
+{
+    return (UIImageView *)self.accessoryView;
+}
+
+- (void)formDescriptorCellDidSelectedWithFormController:(XLFormViewController *)controller
+{
+    alertController = [UIAlertController alertControllerWithTitle: self.rowDescriptor.title
+                                                          message: nil
+                                                   preferredStyle: UIAlertControllerStyleActionSheet];
+    
+    [alertController addAction:[UIAlertAction actionWithTitle: NSLocalizedString(@"Choose From Library", nil)
+                                                        style: UIAlertActionStyleDefault
+                                                      handler: ^(UIAlertAction * _Nonnull action) {
+                                                          [self openImage:UIImagePickerControllerSourceTypePhotoLibrary];
+                                                      }]];
+    
+    if ([UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera]) {
+        [alertController addAction:[UIAlertAction actionWithTitle: NSLocalizedString(@"Take Photo", nil)
+                                                            style: UIAlertActionStyleDefault
+                                                          handler: ^(UIAlertAction * _Nonnull action) {
+                                                              [self openImage:UIImagePickerControllerSourceTypeCamera];
+                                                          }]];
+    }
+    
+    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+        alertController.modalPresentationStyle = UIModalPresentationPopover;
+        alertController.popoverPresentationController.sourceView = self.contentView;
+        alertController.popoverPresentationController.sourceRect = self.contentView.bounds;
+    }
+    
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self.formViewController presentViewController:alertController animated: true completion: nil];
+    });
+}
+
+- (void)openImage:(UIImagePickerControllerSourceType)source
+{
+    imagePickerController = [[UIImagePickerController alloc] init];
+    imagePickerController.delegate = self;
+    imagePickerController.allowsEditing = YES;
+    imagePickerController.sourceType = source;
+    
+    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+        popoverController = [[UIPopoverController alloc] initWithContentViewController:imagePickerController];
+        [popoverController presentPopoverFromRect: self.contentView.frame
+                                           inView: self.formViewController.view
+                         permittedArrowDirections: UIPopoverArrowDirectionAny
+                                         animated: YES];
+    } else {
+        [self.formViewController presentViewController: imagePickerController
+                                              animated: YES
+                                            completion: nil];
+    }
+}
+
+#pragma mark -  UIImagePickerControllerDelegate
+- (void)imagePickerController:(UIImagePickerController *)picker didFinishPickingMediaWithInfo:(NSDictionary<NSString *,id> *)info
+{
+    UIImage *editedImage = info[UIImagePickerControllerEditedImage];
+    UIImage *originalImage = info[UIImagePickerControllerOriginalImage];
+    
+    if (editedImage) {
+        [self chooseImage:editedImage];
+    } else {
+        [self chooseImage:originalImage];
+    }
+    
+    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+        if (popoverController && popoverController.isPopoverVisible) {
+            [popoverController dismissPopoverAnimated: YES];
+        }
+    } else {
+        [self.formViewController dismissViewControllerAnimated: YES completion: nil];
+    }
+}
+
+@end

--- a/XLForm/XL/Controllers/XLFormViewController.m
+++ b/XLForm/XL/Controllers/XLFormViewController.m
@@ -230,6 +230,7 @@
                                                XLFormRowDescriptorTypeSelectorSegmentedControl: [XLFormSegmentedCell class],
                                                XLFormRowDescriptorTypeMultipleSelector: [XLFormSelectorCell class],
                                                XLFormRowDescriptorTypeMultipleSelectorPopover: [XLFormSelectorCell class],
+                                               XLFormRowDescriptorTypeImage: [XLFormImageCell class],
                                                XLFormRowDescriptorTypeTextView: [XLFormTextViewCell class],
                                                XLFormRowDescriptorTypeButton: [XLFormButtonCell class],
                                                XLFormRowDescriptorTypeInfo: [XLFormSelectorCell class],

--- a/XLForm/XL/XLForm.h
+++ b/XLForm/XL/XLForm.h
@@ -68,6 +68,7 @@
 #import "XLFormSwitchCell.h"
 #import "XLFormTextFieldCell.h"
 #import "XLFormTextViewCell.h"
+#import "XLFormImageCell.h"
 
 //Validation
 #import "XLFormRegexValidator.h"
@@ -86,6 +87,7 @@ extern NSString *const XLFormRowDescriptorTypeDateTime;
 extern NSString *const XLFormRowDescriptorTypeDateTimeInline;
 extern NSString *const XLFormRowDescriptorTypeDecimal;
 extern NSString *const XLFormRowDescriptorTypeEmail;
+extern NSString *const XLFormRowDescriptorTypeImage;
 extern NSString *const XLFormRowDescriptorTypeInfo;
 extern NSString *const XLFormRowDescriptorTypeInteger;
 extern NSString *const XLFormRowDescriptorTypeMultipleSelector;

--- a/XLForm/XL/XLForm.m
+++ b/XLForm/XL/XLForm.m
@@ -36,6 +36,7 @@ NSString *const XLFormRowDescriptorTypePhone = @"phone";
 NSString *const XLFormRowDescriptorTypeTwitter = @"twitter";
 NSString *const XLFormRowDescriptorTypeAccount = @"account";
 NSString *const XLFormRowDescriptorTypeInteger = @"integer";
+NSString *const XLFormRowDescriptorTypeImage = @"image";
 NSString *const XLFormRowDescriptorTypeDecimal = @"decimal";
 NSString *const XLFormRowDescriptorTypeTextView = @"textView";
 NSString *const XLFormRowDescriptorTypeZipCode = @"zipCode";


### PR DESCRIPTION
Related to #583

This PR adds a XLFormRowDescriptorTypeImage. 
As a small gif is better than any words. Here is the XLFormRowDescriptorTypeImage in action (from the `OthersFormViewController` example)

![image](https://cloud.githubusercontent.com/assets/235510/11168662/29e90806-8b99-11e5-9d11-a0ac8e9de413.gif)
