### PR TITLE
Added selectorOptionsTintColor

### DIFF
--- a/XLForm/XL/Cell/XLFormLeftRightSelectorCell.m
+++ b/XLForm/XL/Cell/XLFormLeftRightSelectorCell.m
@@ -156,6 +156,7 @@
         if (option.rightOptions){
             XLFormOptionsViewController * optionsViewController = [[XLFormOptionsViewController alloc]  initWithStyle:UITableViewStyleGrouped];
             optionsViewController.title = option.selectorTitle;
+            optionsViewController.tableView.tintColor = self.rowDescriptor.selectorOptionsTintColor;
             optionsViewController.rowDescriptor = self.rowDescriptor;
             [controller.navigationController pushViewController:optionsViewController animated:YES];
         }

--- a/XLForm/XL/Cell/XLFormSelectorCell.m
+++ b/XLForm/XL/Cell/XLFormSelectorCell.m
@@ -192,6 +192,7 @@
             XLFormOptionsViewController * optionsViewController = [[XLFormOptionsViewController alloc] initWithStyle:UITableViewStyleGrouped titleHeaderSection:nil titleFooterSection:nil];
             optionsViewController.rowDescriptor = self.rowDescriptor;
             optionsViewController.title = self.rowDescriptor.selectorTitle;
+            optionsViewController.tableView.tintColor = self.rowDescriptor.selectorOptionsTintColor;
 			
 			if ([self.rowDescriptor.rowType isEqualToString:XLFormRowDescriptorTypeSelectorPopover]) {
 				self.popoverController = [[UIPopoverController alloc] initWithContentViewController:optionsViewController];
@@ -215,6 +216,7 @@
         XLFormOptionsViewController * optionsViewController = [[XLFormOptionsViewController alloc] initWithStyle:UITableViewStyleGrouped titleHeaderSection:nil titleFooterSection:nil];
         optionsViewController.rowDescriptor = self.rowDescriptor;
         optionsViewController.title = self.rowDescriptor.selectorTitle;
+        optionsViewController.tableView.tintColor = self.rowDescriptor.selectorOptionsTintColor;
         
         if ([self.rowDescriptor.rowType isEqualToString:XLFormRowDescriptorTypeMultipleSelectorPopover]) {
             self.popoverController = [[UIPopoverController alloc] initWithContentViewController:optionsViewController];

--- a/XLForm/XL/Descriptors/XLFormRowDescriptor.h
+++ b/XLForm/XL/Descriptors/XLFormRowDescriptor.h
@@ -85,6 +85,7 @@ typedef void(^XLOnChangeBlock)(id __nullable oldValue,id __nullable newValue,XLF
 @property (nullable) NSString * noValueDisplayText;
 @property (nullable) NSString * selectorTitle;
 @property (nullable) NSArray * selectorOptions;
+@property (nullable) UIColor * selectorOptionsTintColor;
 
 @property (null_unspecified) id leftRightSelectorLeftOptionSelected;
 


### PR DESCRIPTION
Added ability to determine tableview tint color for selector options
when pushing optionsViewController: checkmarks will have specified tint
color. I just needed this for my project, don't know if you are interested.