### PR TITLE
Set popover source view for alert controller, fixes crash on iPad

### DIFF
--- a/XLForm/XL/Cell/XLFormSelectorCell.m
+++ b/XLForm/XL/Cell/XLFormSelectorCell.m
@@ -263,6 +263,9 @@
                                                                       [weakSelf.formViewController.tableView reloadData];
                                                                   }]];
             }
+            if ([alertController respondsToSelector:@selector(popoverPresentationController)]) {
+                alertController.popoverPresentationController.sourceView = [controller.tableView cellForRowAtIndexPath:[controller.form indexPathOfFormRow:self.rowDescriptor]];
+            }
             [self.formViewController presentViewController:alertController animated:YES completion:nil];
         }
         else{


### PR DESCRIPTION
Alert Controllers with style Action Sheets are presented as popovers on iPad, but right now XLForm doesn't set a source view for that popover, making the app crash on iPad. This PR seems to fix it :smile: 