### PR TITLE
Fix build error ‘XLFormImageCell.h’ file not found by moving XLFormImageCell from project header to public header

### DIFF
--- a/XLForm.xcodeproj/project.pbxproj
+++ b/XLForm.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		6442F6501C1FC3AA00C9152F /* XLFormImageCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 6442F64E1C1FC3AA00C9152F /* XLFormImageCell.h */; };
+		6442F6501C1FC3AA00C9152F /* XLFormImageCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 6442F64E1C1FC3AA00C9152F /* XLFormImageCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6442F6511C1FC3AA00C9152F /* XLFormImageCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 6442F64F1C1FC3AA00C9152F /* XLFormImageCell.m */; };
 		E267FD7C1BE804E200F86B42 /* XLFormBaseCell.h in Headers */ = {isa = PBXBuildFile; fileRef = E267FD2C1BE804E200F86B42 /* XLFormBaseCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E267FD7D1BE804E200F86B42 /* XLFormBaseCell.m in Sources */ = {isa = PBXBuildFile; fileRef = E267FD2D1BE804E200F86B42 /* XLFormBaseCell.m */; };
@@ -366,7 +366,6 @@
 				E267FDB21BE804E200F86B42 /* NSString+XLFormAdditions.h in Headers */,
 				E267FDB81BE804E200F86B42 /* XLFormRightImageButton.h in Headers */,
 				E267FDA51BE804E200F86B42 /* XLFormDescriptorDelegate.h in Headers */,
-				6442F6501C1FC3AA00C9152F /* XLFormImageCell.h in Headers */,
 				E267FDC41BE804E200F86B42 /* XLFormValidatorProtocol.h in Headers */,
 				E267FDC21BE804E200F86B42 /* XLFormValidator.h in Headers */,
 				E267FDAC1BE804E200F86B42 /* NSExpression+XLFormAdditions.h in Headers */,
@@ -383,6 +382,7 @@
 				E267FD981BE804E200F86B42 /* XLFormTextFieldCell.h in Headers */,
 				E267FD7C1BE804E200F86B42 /* XLFormBaseCell.h in Headers */,
 				E267FD861BE804E200F86B42 /* XLFormDescriptorCell.h in Headers */,
+				6442F6501C1FC3AA00C9152F /* XLFormImageCell.h in Headers */,
 				E267FDA01BE804E200F86B42 /* XLFormRowDescriptorViewController.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
There is a pull request to add XLFormImageCell to project file which got merge and fixed the project compile error:

https://github.com/xmartlabs/XLForm/pull/670

but when we added XLForm to our own project, we still got ```‘XLFormImageCell.h’ file not found```.

Then we found that XLFormImageCell.h was added to `Project` header, not `Public` header, then `XLForm/XLForm.h` couldn't get compiled because of that.

This pull request moved the XLFormImageCell.h to public header so that project referencing XLForm can be compiled.