### PR TITLE
Controlling formatting output when the rowType is XLFormRowDescriptorTypeNumber or XLFormRowDescriptorTypeDecimal

### DIFF
--- a/XLForm/XL/Helpers/NSObject+XLFormAdditions.m
+++ b/XLForm/XL/Helpers/NSObject+XLFormAdditions.m
@@ -31,11 +31,11 @@
 
 -(NSString *)displayText
 {
-    if ([self isKindOfClass:[NSString class]] || [self isKindOfClass:[NSNumber class]]){
-        return [self description];
-    }
     if ([self conformsToProtocol:@protocol(XLFormOptionObject)]){
         return [(id<XLFormOptionObject>)self formDisplayText];
+    }
+    if ([self isKindOfClass:[NSString class]] || [self isKindOfClass:[NSNumber class]]){
+        return [self description];
     }
     return nil;
 }


### PR DESCRIPTION
When setting a form with a row type XLFormRowDescriptorTypeDecimal or XLFormRowDescriptorTypeNumber I can't control the formatting output. For instance, I have a situation when a user typed the number "77.99" and the table row cell displayed "77.98999999999"

I searched a way to fix the output and found that if in NSObject+XLFormAdditions.m you first check for XLFormOptionObject protocol conformance before checking if it's a kind of class NSNumber I can let NSNumber implement XLFormOptionObject and display the correct output:

extension NSNumber: XLFormOptionObject {
    public func formDisplayText() -> String {
       // convert self using NSNumberFormatter and return the correct representation
    }
    public func formValue() -> AnyObject {
        return self
    }
}

Let me know what you think.