### PR TITLE
Changed Release config to use iPhone Distribution code sign identity

### DIFF
--- a/XLForm.xcodeproj/project.pbxproj
+++ b/XLForm.xcodeproj/project.pbxproj
@@ -561,7 +561,7 @@
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 3.0.2;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";


### PR DESCRIPTION
Previously release config was using iPhone Developer. This is incorrect and should use iPhone Distribution.