### PR TITLE
Respect existing content insets

### DIFF
--- a/XLForm/XL/Controllers/XLFormViewController.m
+++ b/XLForm/XL/Controllers/XLFormViewController.m
@@ -60,6 +60,8 @@
 @property UITableViewStyle tableViewStyle;
 @property (nonatomic) XLFormRowNavigationAccessoryView * navigationAccessoryView;
 
+@property UIEdgeInsets cachedInset;
+
 @end
 
 @implementation XLFormViewController
@@ -528,6 +530,7 @@
             [UIView beginAnimations:nil context:nil];
             [UIView setAnimationDuration:[keyboardInfo[UIKeyboardAnimationDurationUserInfoKey] doubleValue]];
             [UIView setAnimationCurve:[keyboardInfo[UIKeyboardAnimationCurveUserInfoKey] intValue]];
+            self.cachedInset = self.tableView.contentInset;
             self.tableView.contentInset = tableContentInset;
             self.tableView.scrollIndicatorInsets = tableScrollIndicatorInsets;
             NSIndexPath *selectedRow = [self.tableView indexPathForCell:cell];
@@ -552,7 +555,7 @@
         [UIView beginAnimations:nil context:nil];
         [UIView setAnimationDuration:[keyboardInfo[UIKeyboardAnimationDurationUserInfoKey] doubleValue]];
         [UIView setAnimationCurve:[keyboardInfo[UIKeyboardAnimationCurveUserInfoKey] intValue]];
-        self.tableView.contentInset = tableContentInset;
+        self.tableView.contentInset = self.cachedInset;
         self.tableView.scrollIndicatorInsets = tableScrollIndicatorInsets;
         [UIView commitAnimations];
     }


### PR DESCRIPTION
Cache any existing content inset before changing to make space for keyboard/editing accessory, restore when keyboard is dismissed