### PR TITLE
fixed a crash

### DIFF
--- a/XLForm/XL/Cell/XLFormBaseCell.m
+++ b/XLForm/XL/Cell/XLFormBaseCell.m
@@ -80,7 +80,7 @@
 {
     id responder = self;
     while (responder){
-        if ([responder isKindOfClass:[UIViewController class]]){
+        if ([responder isKindOfClass:[XLFormViewController class]]){
             return responder;
         }
         responder = [responder nextResponder];


### PR DESCRIPTION
fix bug: fixed UIViewController's instance, does not inherit from XLFormViewController, which tableView using subclass of XLFormBaseCell will crash when its getFirstResponder method is invoked.