### PR TITLE
XLFormDateCell applies cellConfiguration on value change

### DIFF
--- a/XLForm/XL/Cell/XLFormDateCell.m
+++ b/XLForm/XL/Cell/XLFormDateCell.m
@@ -227,9 +227,7 @@
 - (void)datePickerValueChanged:(UIDatePicker *)sender
 {
     self.rowDescriptor.value = sender.date;
-    [self update];
-    [self setNeedsLayout];
-    
+    [self.formViewController updateFormRow:self.rowDescriptor];
 }
 
 -(void)setFormDatePickerMode:(XLFormDateDatePickerMode)formDatePickerMode


### PR DESCRIPTION
Previously, XLFormDateCell would not invoke `updateFormRow` on its `formViewController`.

This caused an issue where custom cell settings in `cellConfig` would get overriden whenever the date changes.