### PR TITLE
Swift-friendly init methods

### DIFF
--- a/XLForm/XL/Controllers/XLFormViewController.h
+++ b/XLForm/XL/Controllers/XLFormViewController.h
@@ -83,8 +83,9 @@ typedef NS_ENUM(NSUInteger, XLFormRowNavigationDirection) {
 @property XLFormDescriptor * form;
 @property IBOutlet UITableView * tableView;
 
--(id)initWithForm:(XLFormDescriptor *)form;
--(id)initWithForm:(XLFormDescriptor *)form style:(UITableViewStyle)style;
+-(instancetype)initWithForm:(XLFormDescriptor *)form;
+-(instancetype)initWithForm:(XLFormDescriptor *)form style:(UITableViewStyle)style NS_DESIGNATED_INITIALIZER;
+-(instancetype)initWithCoder:(NSCoder *)aDecoder NS_DESIGNATED_INITIALIZER;
 +(NSMutableDictionary *)cellClassesForRowDescriptorTypes;
 +(NSMutableDictionary *)inlineRowDescriptorTypesForRowDescriptorTypes;
 

--- a/XLForm/XL/Controllers/XLFormViewController.m
+++ b/XLForm/XL/Controllers/XLFormViewController.m
@@ -75,7 +75,7 @@
 
 -(id)initWithForm:(XLFormDescriptor *)form style:(UITableViewStyle)style
 {
-    self = [self initWithNibName:nil bundle:nil];
+    self = [super initWithNibName:nil bundle:nil];
     if (self){
         _tableViewStyle = style;
         _form = form;
@@ -85,26 +85,18 @@
 
 -(id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
 {
-    self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
-    if (self){
-        [self defaultInitialize];
-    }
-    return self;
+    return [self initWithForm:nil style:UITableViewStyleGrouped];
 }
 
--(id)initWithCoder:(NSCoder *)aDecoder
+-(instancetype)initWithCoder:(NSCoder *)aDecoder
 {
     self = [super initWithCoder:aDecoder];
-    if (self){
-        [self defaultInitialize];
+    if (self) {
+        _form = nil;
+        _tableViewStyle = UITableViewStyleGrouped;
     }
+    
     return self;
-}
-
--(void)defaultInitialize
-{
-    _form = nil;
-    _tableViewStyle = UITableViewStyleGrouped;
 }
 
 - (void)dealloc


### PR DESCRIPTION
Currently a XLFormViewController-subclass in Swift cannot have a custom init (it will crash at runtime with an 'unimplemented initializer' error). This fix adds designated initializer markings on the view controller and refactors them to all call the designated initializer.