### PR TITLE
XLFormLeftRightSelectorOption left value change policy

### DIFF
--- a/Examples/Objective-C/Examples/Selectors/SelectorsFormViewController.m
+++ b/Examples/Objective-C/Examples/Selectors/SelectorsFormViewController.m
@@ -212,11 +212,13 @@ NSString *const kSelectorWithStoryboardId = @"selectorWithStoryboardId";
     mutableRightOptions = [rightOptions mutableCopy];
     [mutableRightOptions removeObjectAtIndex:1];
     leftRightSelectorOption = [XLFormLeftRightSelectorOption formLeftRightSelectorOptionWithLeftValue:[XLFormOptionsObject formOptionsObjectWithValue:@(1) displayText:@"Option 2"] httpParameterKey:@"option_2" rightOptions:mutableRightOptions];
+    leftRightSelectorOption.leftValueChangePolicy = XLFormLeftRightSelectorOptionLeftValueChangePolicyChooseFirstOption;
     [leftRightSelectorOptions addObject:leftRightSelectorOption];
     
     mutableRightOptions = [rightOptions mutableCopy];
     [mutableRightOptions removeObjectAtIndex:2];
     leftRightSelectorOption = [XLFormLeftRightSelectorOption formLeftRightSelectorOptionWithLeftValue:[XLFormOptionsObject formOptionsObjectWithValue:@(2) displayText:@"Option 3"]  httpParameterKey:@"option_3" rightOptions:mutableRightOptions];
+    leftRightSelectorOption.leftValueChangePolicy = XLFormLeftRightSelectorOptionLeftValueChangePolicyChooseLastOption;
     [leftRightSelectorOptions addObject:leftRightSelectorOption];
     
     mutableRightOptions = [rightOptions mutableCopy];

--- a/XLForm/XL/Cell/XLFormLeftRightSelectorCell.m
+++ b/XLForm/XL/Cell/XLFormLeftRightSelectorCell.m
@@ -176,6 +176,19 @@
     return option.httpParameterKey;
 }
 
+- (id) chooseNewRightValueFromOption:(XLFormLeftRightSelectorOption*)option
+{
+    switch (option.leftValueChangePolicy) {
+        case XLFormLeftRightSelectorOptionLeftValueChangePolicyChooseLastOption:
+            return [option.rightOptions lastObject];
+        case XLFormLeftRightSelectorOptionLeftValueChangePolicyChooseFirstOption:
+            return [option.rightOptions firstObject];
+        case XLFormLeftRightSelectorOptionLeftValueChangePolicyNullifyRightValue:
+            return nil;
+    }
+    return nil;
+}
+
 
 #pragma mark - Actions
 
@@ -207,7 +220,7 @@
             [alertController addAction:[UIAlertAction actionWithTitle:[leftOption.leftValue displayText]
                                                                 style:UIAlertActionStyleDefault
                                                               handler:^(UIAlertAction *action) {
-                                                                  weakSelf.rowDescriptor.value = nil;
+                                                                  weakSelf.rowDescriptor.value = [self chooseNewRightValueFromOption:leftOption];
                                                                   weakSelf.rowDescriptor.leftRightSelectorLeftOptionSelected = [self leftOptionForDescription:[leftOption.leftValue displayText]].leftValue;
                                                                   [weakSelf.formViewController updateFormRow:weakSelf.rowDescriptor];
                                                               }]];
@@ -242,7 +255,7 @@
     if ([actionSheet cancelButtonIndex] != buttonIndex){
         NSString * title = [actionSheet buttonTitleAtIndex:buttonIndex];
         if (![self.rowDescriptor.leftRightSelectorLeftOptionSelected isEqual:[self leftOptionForDescription:title].leftValue]){            
-            self.rowDescriptor.value = nil;
+            self.rowDescriptor.value = [self chooseNewRightValueFromOption:leftOption];
             self.rowDescriptor.leftRightSelectorLeftOptionSelected = [self leftOptionForDescription:title].leftValue;
             [self.formViewController updateFormRow:self.rowDescriptor];
         }

--- a/XLForm/XL/Cell/XLFormLeftRightSelectorCell.m
+++ b/XLForm/XL/Cell/XLFormLeftRightSelectorCell.m
@@ -255,7 +255,7 @@
     if ([actionSheet cancelButtonIndex] != buttonIndex){
         NSString * title = [actionSheet buttonTitleAtIndex:buttonIndex];
         if (![self.rowDescriptor.leftRightSelectorLeftOptionSelected isEqual:[self leftOptionForDescription:title].leftValue]){            
-            self.rowDescriptor.value = [self chooseNewRightValueFromOption:leftOption];
+            self.rowDescriptor.value = [self chooseNewRightValueFromOption:[self leftOptionForDescription:title]];
             self.rowDescriptor.leftRightSelectorLeftOptionSelected = [self leftOptionForDescription:title].leftValue;
             [self.formViewController updateFormRow:self.rowDescriptor];
         }

--- a/XLForm/XL/Descriptors/XLFormRowDescriptor.h
+++ b/XLForm/XL/Descriptors/XLFormRowDescriptor.h
@@ -100,12 +100,20 @@ typedef void(^XLOnChangeBlock)(id __nullable oldValue,id __nullable newValue,XLF
 
 @end
 
+typedef NS_ENUM(NSUInteger, XLFormLeftRightSelectorOptionLeftValueChangePolicy)
+{
+    XLFormLeftRightSelectorOptionLeftValueChangePolicyNullifyRightValue,
+    XLFormLeftRightSelectorOptionLeftValueChangePolicyChooseFirstOption,
+    XLFormLeftRightSelectorOptionLeftValueChangePolicyChooseLastOption
+};
+
 
 // =====================================
 // helper object used for LEFTRIGHTSelector Descriptor
 // =====================================
 @interface XLFormLeftRightSelectorOption : NSObject
 
+@property (nonatomic, assign) XLFormLeftRightSelectorOptionLeftValueChangePolicy leftValueChangePolicy;
 @property (readonly, nonnull) id leftValue;
 @property (readonly, nonnull) NSArray *  rightOptions;
 @property (readonly, null_unspecified) NSString * httpParameterKey;

--- a/XLForm/XL/Descriptors/XLFormRowDescriptor.h
+++ b/XLForm/XL/Descriptors/XLFormRowDescriptor.h
@@ -102,7 +102,7 @@ typedef void(^XLOnChangeBlock)(id __nullable oldValue,id __nullable newValue,XLF
 
 typedef NS_ENUM(NSUInteger, XLFormLeftRightSelectorOptionLeftValueChangePolicy)
 {
-    XLFormLeftRightSelectorOptionLeftValueChangePolicyNullifyRightValue,
+    XLFormLeftRightSelectorOptionLeftValueChangePolicyNullifyRightValue = 0,
     XLFormLeftRightSelectorOptionLeftValueChangePolicyChooseFirstOption,
     XLFormLeftRightSelectorOptionLeftValueChangePolicyChooseLastOption
 };


### PR DESCRIPTION
Hi! Currently row with `XLFormRowDescriptorTypeSelectorLeftRight` type resets its right value when user chooses new left value. But in our app we need to choose first value from right options automatically. So we propose to introduce new property in `XLFormLeftRightSelectorOption` called `leftValueChangePolicy`. It will preserve backward compatibility, because default value is XLFormLeftRightSelectorOptionLeftValueChangePolicyNullifyRightValue. It will reset right value to nil the same way it was before.