### PR TITLE
fix crash when adding a validator to a copied row descriptor

### DIFF
--- a/XLForm/XL/Descriptors/XLFormRowDescriptor.m
+++ b/XLForm/XL/Descriptors/XLFormRowDescriptor.m
@@ -203,7 +203,7 @@
     rowDescriptorCopy.required = self.isRequired;
     rowDescriptorCopy.isDirtyDisablePredicateCache = YES;
     rowDescriptorCopy.isDirtyHidePredicateCache = YES;
-    rowDescriptorCopy.validators = [self.validators copy];
+    rowDescriptorCopy.validators = [self.validators mutableCopy];
 
     // =====================
     // properties for Button


### PR DESCRIPTION
A crash will occur when attempting to add an XLFormValidator to a copied XLFormRowDescriptor, usually from a multivalued row.  In XLFormRowDescriptor.m, when using copyWithZone: the validators property is incorrectly copied as an immutable array.  It should be a mutable copy.