### PR TITLE
Fixed selector action sheet to use the row's value transformer

### DIFF
--- a/XLForm/XL/Cell/XLFormSelectorCell.m
+++ b/XLForm/XL/Cell/XLFormSelectorCell.m
@@ -266,6 +266,15 @@
             alertController.popoverPresentationController.sourceRect = [formViewController.tableView convertRect:v.frame fromView:self];
             __weak __typeof(self)weakSelf = self;
             for (id option in self.rowDescriptor.selectorOptions) {
+				NSString *optionTitle = [option displayText];
+				if (self.rowDescriptor.valueTransformer){
+					NSAssert([self.rowDescriptor.valueTransformer isSubclassOfClass:[NSValueTransformer class]], @"valueTransformer is not a subclass of NSValueTransformer");
+					NSValueTransformer * valueTransformer = [self.rowDescriptor.valueTransformer new];
+					NSString * transformedValue = [valueTransformer transformedValue:[option valueData]];
+					if (transformedValue) {
+						optionTitle = transformedValue;
+					}
+				}
                 [alertController addAction:[UIAlertAction actionWithTitle:[option displayText]
                                                                     style:UIAlertActionStyleDefault
                                                                   handler:^(UIAlertAction *action) {
@@ -274,6 +283,8 @@
                                                                   }]];
             }
             [formViewController presentViewController:alertController animated:YES completion:nil];
+            // Fix for "Snapshotting a view that has not been rendered results in an empty snapshot." bug
+            [[alertController view] layoutIfNeeded];
         }
 #ifndef XL_APP_EXTENSIONS
         else{

--- a/XLForm/XL/Cell/XLFormSelectorCell.m
+++ b/XLForm/XL/Cell/XLFormSelectorCell.m
@@ -283,8 +283,6 @@
                                                                   }]];
             }
             [formViewController presentViewController:alertController animated:YES completion:nil];
-            // Fix for "Snapshotting a view that has not been rendered results in an empty snapshot." bug
-            [[alertController view] layoutIfNeeded];
         }
 #ifndef XL_APP_EXTENSIONS
         else{

--- a/XLForm/XL/Cell/XLFormSelectorCell.m
+++ b/XLForm/XL/Cell/XLFormSelectorCell.m
@@ -275,7 +275,7 @@
 						optionTitle = transformedValue;
 					}
 				}
-                [alertController addAction:[UIAlertAction actionWithTitle:[option displayText]
+                [alertController addAction:[UIAlertAction actionWithTitle:optionTitle
                                                                     style:UIAlertActionStyleDefault
                                                                   handler:^(UIAlertAction *action) {
                                                                       [weakSelf.rowDescriptor setValue:option];


### PR DESCRIPTION
It appears that the XLFormRowDescriptorTypeSelectorActionSheet does not use the rowDescriptor's valueTransformer property, which is useful when the options are of an enum type and a transformer is used for the display text.