### PR TITLE
[fixes #452] respect the currentLocale when parsing decimal values

### DIFF
--- a/XLForm/XL/Cell/XLFormTextFieldCell.m
+++ b/XLForm/XL/Cell/XLFormTextFieldCell.m
@@ -331,7 +331,7 @@ NSString *const XLFormTextFieldLengthPercentage = @"textFieldLengthPercentage";
         if (!didUseFormatter)
         {
             if ([self.rowDescriptor.rowType isEqualToString:XLFormRowDescriptorTypeNumber] || [self.rowDescriptor.rowType isEqualToString:XLFormRowDescriptorTypeDecimal]){
-                self.rowDescriptor.value =  [NSDecimalNumber decimalNumberWithString: self.textField.text];
+                self.rowDescriptor.value =  [NSDecimalNumber decimalNumberWithString:self.textField.text locale:NSLocale.currentLocale];
             } else if ([self.rowDescriptor.rowType isEqualToString:XLFormRowDescriptorTypeInteger]){
                 self.rowDescriptor.value = @([self.textField.text integerValue]);
             } else {


### PR DESCRIPTION
#452 was actually not fixed yet. This commit makes NSDecimalNumber respect the currentLocale when parsing decimal form field values. This allows ',' as a decimal separator and not just '.'.