### PR TITLE
Set tintColor of newly created cells according to formController's view

### DIFF
--- a/XLForm/XL/Descriptors/XLFormRowDescriptor.m
+++ b/XLForm/XL/Descriptors/XLFormRowDescriptor.m
@@ -143,7 +143,7 @@ CGFloat XLFormRowInitialHeight = -2;
             }
         } else {
             _cell = [[cellClass alloc] initWithStyle:self.cellStyle reuseIdentifier:nil];
-			_cell.tintColor = formController.view.tintColor;
+            _cell.tintColor = formController.view.tintColor;
         }
         _cell.rowDescriptor = self;
         NSAssert([_cell isKindOfClass:[XLFormBaseCell class]], @"UITableViewCell must extend from XLFormBaseCell");

--- a/XLForm/XL/Descriptors/XLFormRowDescriptor.m
+++ b/XLForm/XL/Descriptors/XLFormRowDescriptor.m
@@ -116,7 +116,7 @@ CGFloat XLFormRowInitialHeight = -2;
     return [[[self class] alloc] initWithTag:tag rowType:rowType title:title];
 }
 
--(XLFormBaseCell *)cellForFormController:(XLFormViewController * __unused)formController
+-(XLFormBaseCell *)cellForFormController:(XLFormViewController *)formController
 {
     if (!_cell){
         id cellClass = self.cellClass ?: [XLFormViewController cellClassesForRowDescriptorTypes][self.rowType];
@@ -143,6 +143,7 @@ CGFloat XLFormRowInitialHeight = -2;
             }
         } else {
             _cell = [[cellClass alloc] initWithStyle:self.cellStyle reuseIdentifier:nil];
+			_cell.tintColor = formController.view.tintColor;
         }
         _cell.rowDescriptor = self;
         NSAssert([_cell isKindOfClass:[XLFormBaseCell class]], @"UITableViewCell must extend from XLFormBaseCell");


### PR DESCRIPTION
I'm using storyboards and cells created by XLForm always have the default (blue) `tintColor` even though the storyboard has a different global `tintColor` set. That's why I'm setting the `tintColor` of newly created cells to the `tintColor` of `formController.view`.