### PR TITLE
Limit number of characters in XLFormTextFieldCell and XLFormTextViewCell

### DIFF
--- a/Tests/XLForm Tests.xcodeproj/project.pbxproj
+++ b/Tests/XLForm Tests.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		28657A54199154EE00CE8180 /* XLFormValidatorsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 28657A53199154EE00CE8180 /* XLFormValidatorsTests.m */; };
 		3C5B9B7A1AC0BA33000AF1BA /* XLFormExampleTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C5B9B791AC0BA33000AF1BA /* XLFormExampleTest.m */; };
 		3C9817861AC30616003F6ABD /* UITextField+Test.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C9817851AC30616003F6ABD /* UITextField+Test.m */; };
+		6233D65F1D7DF022000E7716 /* XLTestTextViewProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = 6233D65E1D7DF022000E7716 /* XLTestTextViewProperties.m */; };
 		BFD111841AD8323900943D23 /* XLTestHideAndShow.m in Sources */ = {isa = PBXBuildFile; fileRef = BFD111831AD8323900943D23 /* XLTestHideAndShow.m */; };
 /* End PBXBuildFile section */
 
@@ -37,6 +38,7 @@
 		3C5B9B791AC0BA33000AF1BA /* XLFormExampleTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XLFormExampleTest.m; path = Test/XLFormExampleTest.m; sourceTree = "<group>"; };
 		3C9817841AC30616003F6ABD /* UITextField+Test.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UITextField+Test.h"; path = "Helpers/UITextField+Test.h"; sourceTree = "<group>"; };
 		3C9817851AC30616003F6ABD /* UITextField+Test.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UITextField+Test.m"; path = "Helpers/UITextField+Test.m"; sourceTree = "<group>"; };
+		6233D65E1D7DF022000E7716 /* XLTestTextViewProperties.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XLTestTextViewProperties.m; path = Test/XLTestTextViewProperties.m; sourceTree = "<group>"; };
 		8ADC094C94CA7ABBB8134573 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 		BFD111831AD8323900943D23 /* XLTestHideAndShow.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XLTestHideAndShow.m; path = Test/XLTestHideAndShow.m; sourceTree = "<group>"; };
 		C6B20EA1A9D9591335BEE81F /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
@@ -118,6 +120,7 @@
 				28657A5119914F9700CE8180 /* XLTestCase.m */,
 				28657A53199154EE00CE8180 /* XLFormValidatorsTests.m */,
 				03885A901D7DD3BD00CC183A /* XLTestTextFieldProperties.m */,
+				6233D65E1D7DF022000E7716 /* XLTestTextViewProperties.m */,
 			);
 			name = Tests;
 			sourceTree = "<group>";
@@ -258,6 +261,7 @@
 				28657A5219914F9700CE8180 /* XLTestCase.m in Sources */,
 				03885A911D7DD3BD00CC183A /* XLTestTextFieldProperties.m in Sources */,
 				BFD111841AD8323900943D23 /* XLTestHideAndShow.m in Sources */,
+				6233D65F1D7DF022000E7716 /* XLTestTextViewProperties.m in Sources */,
 				3C5B9B7A1AC0BA33000AF1BA /* XLFormExampleTest.m in Sources */,
 				3C9817861AC30616003F6ABD /* UITextField+Test.m in Sources */,
 			);

--- a/Tests/XLForm Tests.xcodeproj/project.pbxproj
+++ b/Tests/XLForm Tests.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		03885A911D7DD3BD00CC183A /* XLTestTextFieldProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = 03885A901D7DD3BD00CC183A /* XLTestTextFieldProperties.m */; };
 		17538872B9BB29167787CF50 /* libPods-XLForm Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E68572C5C8328F0F177BBCA1 /* libPods-XLForm Tests.a */; };
 		28657A3E1990879200CE8180 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28657A3D1990879200CE8180 /* XCTest.framework */; };
 		28657A401990879200CE8180 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28657A3F1990879200CE8180 /* Foundation.framework */; };
@@ -20,6 +21,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		03885A901D7DD3BD00CC183A /* XLTestTextFieldProperties.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XLTestTextFieldProperties.m; path = Test/XLTestTextFieldProperties.m; sourceTree = "<group>"; };
 		28657A3A1990879200CE8180 /* XLForm Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "XLForm Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		28657A3D1990879200CE8180 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		28657A3F1990879200CE8180 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
@@ -115,6 +117,7 @@
 				28657A5019914F9700CE8180 /* XLTestCase.h */,
 				28657A5119914F9700CE8180 /* XLTestCase.m */,
 				28657A53199154EE00CE8180 /* XLFormValidatorsTests.m */,
+				03885A901D7DD3BD00CC183A /* XLTestTextFieldProperties.m */,
 			);
 			name = Tests;
 			sourceTree = "<group>";
@@ -146,12 +149,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 28657A4C1990879200CE8180 /* Build configuration list for PBXNativeTarget "XLForm Tests" */;
 			buildPhases = (
-				6B058765CC1143829C6943B9 /* 📦 Check Pods Manifest.lock */,
+				6B058765CC1143829C6943B9 /* [CP] Check Pods Manifest.lock */,
 				28657A361990879200CE8180 /* Sources */,
 				28657A371990879200CE8180 /* Frameworks */,
 				28657A381990879200CE8180 /* Resources */,
-				3E5FCF05A57F40C6AF367F6D /* 📦 Copy Pods Resources */,
-				6A2C507B76209618EDA57426 /* 📦 Embed Pods Frameworks */,
+				3E5FCF05A57F40C6AF367F6D /* [CP] Copy Pods Resources */,
+				6A2C507B76209618EDA57426 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -199,14 +202,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		3E5FCF05A57F40C6AF367F6D /* 📦 Copy Pods Resources */ = {
+		3E5FCF05A57F40C6AF367F6D /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -214,14 +217,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-XLForm Tests/Pods-XLForm Tests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		6A2C507B76209618EDA57426 /* 📦 Embed Pods Frameworks */ = {
+		6A2C507B76209618EDA57426 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Embed Pods Frameworks";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -229,19 +232,19 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-XLForm Tests/Pods-XLForm Tests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		6B058765CC1143829C6943B9 /* 📦 Check Pods Manifest.lock */ = {
+		6B058765CC1143829C6943B9 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -253,6 +256,7 @@
 			files = (
 				28657A54199154EE00CE8180 /* XLFormValidatorsTests.m in Sources */,
 				28657A5219914F9700CE8180 /* XLTestCase.m in Sources */,
+				03885A911D7DD3BD00CC183A /* XLTestTextFieldProperties.m in Sources */,
 				BFD111841AD8323900943D23 /* XLTestHideAndShow.m in Sources */,
 				3C5B9B7A1AC0BA33000AF1BA /* XLFormExampleTest.m in Sources */,
 				3C9817861AC30616003F6ABD /* UITextField+Test.m in Sources */,

--- a/Tests/XLForm Tests/Test/XLTestTextFieldProperties.m
+++ b/Tests/XLForm Tests/Test/XLTestTextFieldProperties.m
@@ -1,5 +1,5 @@
 //
-//  XLFormViewControllerTestCase.m
+//  XLTestTextFieldProperties.m
 //  XLForm Tests
 //
 //  Created by Claus on 9/5/16.

--- a/Tests/XLForm Tests/Test/XLTestTextFieldProperties.m
+++ b/Tests/XLForm Tests/Test/XLTestTextFieldProperties.m
@@ -1,0 +1,66 @@
+//
+//  XLFormViewControllerTestCase.m
+//  XLForm Tests
+//
+//  Created by Claus on 9/5/16.
+//
+//
+
+#import "XLTestCase.h"
+#import <XLForm/XLFormTextFieldCell.h>
+#import <UIKit/UIKit.h>
+
+@interface XLTestTextFieldProperties : XLTestCase
+@end
+
+@implementation XLTestTextFieldProperties
+
+- (void)testPropertiesGetSet
+{
+    // Get the tableView
+    UITableView * tableView = self.formController.tableView;
+    
+    UITableViewCell * cell = [self.formController tableView:tableView cellForRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0]];
+
+    // Check if the cell contains the correct properties
+    expect(cell).to.beKindOf([XLFormTextFieldCell class]);
+    XLFormTextFieldCell * textFieldCell = (XLFormTextFieldCell *)cell;
+    expect(textFieldCell.textFieldLengthPercentage).to.equal(0.3);
+    expect(textFieldCell.textFieldMaxNumberOfCharacters).to.equal(10);
+}
+
+- (void)testMaxNumbersOfCharacters
+{
+    // Get the tableView
+    UITableView * tableView = self.formController.tableView;
+
+    UITableViewCell * cell = [self.formController tableView:tableView cellForRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0]];
+    expect(cell).to.beKindOf([XLFormTextFieldCell class]);
+    XLFormTextFieldCell * textFieldCell = (XLFormTextFieldCell *)cell;
+
+    // Check if range check works
+    expect(cell).to.conformTo(@protocol(UITextFieldDelegate));
+    id<UITextFieldDelegate> textFieldDelegate = (id<UITextFieldDelegate>)cell;
+    NSRange range = NSMakeRange(0, 0);
+    expect([textFieldDelegate textField:textFieldCell.textField shouldChangeCharactersInRange:range replacementString:@"123"]).to.beTruthy();
+    expect([textFieldDelegate textField:textFieldCell.textField shouldChangeCharactersInRange:range replacementString:@"1234567890"]).to.beTruthy();
+    expect([textFieldDelegate textField:textFieldCell.textField shouldChangeCharactersInRange:range replacementString:@"12345678901"]).to.beFalsy();
+}
+
+#pragma mark - Build Form
+
+-(void)buildForm
+{
+    XLFormDescriptor * form = [XLFormDescriptor formDescriptor];
+    XLFormSectionDescriptor * section = [XLFormSectionDescriptor formSection];
+    [form addFormSection:section];
+    
+    XLFormRowDescriptor * row = [XLFormRowDescriptor formRowDescriptorWithTag:nil rowType:XLFormRowDescriptorTypeText];
+    [row.cellConfigAtConfigure setObject:@(0.3) forKey:XLFormTextFieldLengthPercentage];
+    [row.cellConfigAtConfigure setObject:@(10) forKey:XLFormTextFieldMaxNumberOfCharacters];
+    [section addFormRow:row];
+    
+    self.formController.form = form;
+}
+
+@end

--- a/Tests/XLForm Tests/Test/XLTestTextViewProperties.m
+++ b/Tests/XLForm Tests/Test/XLTestTextViewProperties.m
@@ -1,0 +1,66 @@
+//
+//  XLTestTextViewProperties.m
+//  XLForm Tests
+//
+//  Created by Claus on 9/5/16.
+//
+//
+
+#import "XLTestCase.h"
+#import <XLForm/XLFormTextViewCell.h>
+#import <UIKit/UIKit.h>
+
+@interface XLTestTextViewProperties : XLTestCase
+@end
+
+@implementation XLTestTextViewProperties
+
+- (void)testPropertiesGetSet
+{
+    // Get the tableView
+    UITableView * tableView = self.formController.tableView;
+    
+    UITableViewCell * cell = [self.formController tableView:tableView cellForRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0]];
+
+    // Check if the cell contains the correct properties
+    expect(cell).to.beKindOf([XLFormTextViewCell class]);
+    XLFormTextViewCell * textViewCell = (XLFormTextViewCell *)cell;
+    expect(textViewCell.textViewLengthPercentage).to.equal(0.3);
+    expect(textViewCell.textViewMaxNumberOfCharacters).to.equal(10);
+}
+
+- (void)testMaxNumbersOfCharacters
+{
+    // Get the tableView
+    UITableView * tableView = self.formController.tableView;
+
+    UITableViewCell * cell = [self.formController tableView:tableView cellForRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0]];
+    expect(cell).to.beKindOf([XLFormTextViewCell class]);
+    XLFormTextViewCell * textViewCell = (XLFormTextViewCell *)cell;
+
+    // Check if range check works
+    expect(cell).to.conformTo(@protocol(UITextViewDelegate));
+    id<UITextViewDelegate> textFieldDelegate = (id<UITextViewDelegate>)cell;
+    NSRange range = NSMakeRange(0, 0);
+    expect([textFieldDelegate textView:textViewCell.textView shouldChangeTextInRange:range replacementText:@"123"]).to.beTruthy();
+    expect([textFieldDelegate textView:textViewCell.textView shouldChangeTextInRange:range replacementText:@"1234567890"]).to.beTruthy();
+    expect([textFieldDelegate textView:textViewCell.textView shouldChangeTextInRange:range replacementText:@"12345678901"]).to.beFalsy();
+}
+
+#pragma mark - Build Form
+
+-(void)buildForm
+{
+    XLFormDescriptor * form = [XLFormDescriptor formDescriptor];
+    XLFormSectionDescriptor * section = [XLFormSectionDescriptor formSection];
+    [form addFormSection:section];
+    
+    XLFormRowDescriptor * row = [XLFormRowDescriptor formRowDescriptorWithTag:nil rowType:XLFormRowDescriptorTypeTextView];
+    [row.cellConfigAtConfigure setObject:@(0.3) forKey:XLFormTextViewLengthPercentage];
+    [row.cellConfigAtConfigure setObject:@(10) forKey:XLFormTextViewMaxNumberOfCharacters];
+    [section addFormRow:row];
+    
+    self.formController.form = form;
+}
+
+@end

--- a/XLForm/XL/Cell/XLFormTextFieldCell.h
+++ b/XLForm/XL/Cell/XLFormTextFieldCell.h
@@ -27,6 +27,7 @@
 #import <UIKit/UIKit.h>
 
 extern NSString *const XLFormTextFieldLengthPercentage;
+extern NSString *const XLFormTextFieldMaxNumberOfCharacters;
 
 @interface XLFormTextFieldCell : XLFormBaseCell <XLFormReturnKeyProtocol>
 
@@ -34,5 +35,6 @@ extern NSString *const XLFormTextFieldLengthPercentage;
 @property (nonatomic, readonly) UITextField * textField;
 
 @property (nonatomic) NSNumber *textFieldLengthPercentage;
+@property (nonatomic) NSNumber *textFieldMaxNumberOfCharacters;
 
 @end

--- a/XLForm/XL/Cell/XLFormTextFieldCell.m
+++ b/XLForm/XL/Cell/XLFormTextFieldCell.m
@@ -30,6 +30,7 @@
 #import "XLFormTextFieldCell.h"
 
 NSString *const XLFormTextFieldLengthPercentage = @"textFieldLengthPercentage";
+NSString *const XLFormTextFieldMaxNumberOfCharacters = @"textFieldMaxNumberOfCharacters";
 
 @interface XLFormTextFieldCell() <UITextFieldDelegate>
 
@@ -278,6 +279,15 @@ NSString *const XLFormTextFieldLengthPercentage = @"textFieldLengthPercentage";
 }
 
 - (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string {
+    if (self.textFieldMaxNumberOfCharacters) {
+        // Check maximum length requirement
+        NSString *newString = [textField.text stringByReplacingCharactersInRange:range withString:string];
+        if (newString.length > self.textFieldMaxNumberOfCharacters.integerValue) {
+            return NO;
+        }
+    }
+
+    // Otherwise, leave response to view controller
     return [self.formViewController textField:textField shouldChangeCharactersInRange:range replacementString:string];
 }
 

--- a/XLForm/XL/Cell/XLFormTextViewCell.h
+++ b/XLForm/XL/Cell/XLFormTextViewCell.h
@@ -28,6 +28,7 @@
 #import <UIKit/UIKit.h>
 
 extern NSString *const XLFormTextViewLengthPercentage;
+extern NSString *const XLFormTextViewMaxNumberOfCharacters;
 
 @interface XLFormTextViewCell : XLFormBaseCell
 
@@ -36,5 +37,6 @@ extern NSString *const XLFormTextViewLengthPercentage;
 @property (nonatomic, readonly) XLFormTextView * textView;
 
 @property (nonatomic) NSNumber *textViewLengthPercentage;
+@property (nonatomic) NSNumber *textViewMaxNumberOfCharacters;
 
 @end

--- a/XLForm/XL/Cell/XLFormTextViewCell.m
+++ b/XLForm/XL/Cell/XLFormTextViewCell.m
@@ -29,8 +29,8 @@
 #import "XLFormTextView.h"
 #import "XLFormTextViewCell.h"
 
-NSString *const kFormTextViewCellPlaceholder = @"placeholder";
 NSString *const XLFormTextViewLengthPercentage = @"textViewLengthPercentage";
+NSString *const XLFormTextViewMaxNumberOfCharacters = @"textViewMaxNumberOfCharacters";
 
 @interface XLFormTextViewCell() <UITextViewDelegate>
 
@@ -207,6 +207,15 @@ NSString *const XLFormTextViewLengthPercentage = @"textViewLengthPercentage";
 }
 
 - (BOOL)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)text {
+    if (self.textViewMaxNumberOfCharacters) {
+        // Check maximum length requirement
+        NSString *newText = [textView.text stringByReplacingCharactersInRange:range withString:text];
+        if (newText.length > self.textViewMaxNumberOfCharacters.integerValue) {
+            return NO;
+        }
+    }
+    
+    // Otherwise, leave response to view controller
 	return [self.formViewController textView:textView shouldChangeTextInRange:range replacementText:text];
 }
 


### PR DESCRIPTION
I implemented #855 by adding a new property in `XLFormTextFieldCell` (similar to the existing `textFieldLengthPercentage`) and checking the limit in `textField:shouldChangeCharactersInRange:replacementString:`. The commit also includes a unit test for validating the property and the range check.

I also made the same change to `XLFormTextViewCell`

Would be great if you would merge this useful addition to your library.