### PR TITLE
OptionsRow-Deselect

### DIFF
--- a/XLForm/XL/Controllers/XLFormOptionsViewController.m
+++ b/XLForm/XL/Controllers/XLFormOptionsViewController.m
@@ -138,8 +138,8 @@
         if ([[self.rowDescriptor.value valueData] isEqual:[cellObject valueData]]){
             if (!self.rowDescriptor.required){
                 self.rowDescriptor.value = nil;
+				cell.accessoryType = UITableViewCellAccessoryNone;
             }
-            cell.accessoryType = UITableViewCellAccessoryNone;
         }
         else{
             if (self.rowDescriptor.value){


### PR DESCRIPTION
Prevents setting cell's accessoryType to UITableViewCellAccessoryNone if the rowDescriptor's required value is true.

This fixes the ability to deselect options when using XLFormRowDescriptorTypeSelectorPush.

Fixes: https://github.com/xmartlabs/XLForm/issues/846