### PR TITLE
Fix use of formatter in Info Cells

### DIFF
--- a/Examples/Objective-C/Examples/Formatters/FormattersViewController.m
+++ b/Examples/Objective-C/Examples/Formatters/FormattersViewController.m
@@ -105,6 +105,11 @@
     [row.cellConfigAtConfigure setObject:@(NSTextAlignmentRight) forKey:@"textField.textAlignment"];
     [section addFormRow:row];
     
+    row = [XLFormRowDescriptor formRowDescriptorWithTag:@"megabytes" rowType:XLFormRowDescriptorTypeInfo title:@"Megabytes"];
+    row.valueFormatter = [NSByteCountFormatter new];
+    row.value = @(1024);
+    [section addFormRow:row];
+    
     section = [XLFormSectionDescriptor formSection];
     [formDescriptor addFormSection:section];
     

--- a/XLForm/XL/Cell/XLFormSelectorCell.m
+++ b/XLForm/XL/Cell/XLFormSelectorCell.m
@@ -87,7 +87,7 @@
             return tranformedValue;
         }
     }
-    return [self.rowDescriptor.value displayText];
+    return self.rowDescriptor.displayTextValue;
 }
 
 


### PR DESCRIPTION
Currently it will not use the provided `valueFormatter` if the row is `XLFormRowDescriptorTypeInfo`.

- To reproduce this issue I added an extra row to the `FormattersViewController` using `NSByteCountFormatter` ea96fe9
- To fix I made `XLFormRowDescriptor` conform  to `XLFormOptionObject` so it will format using the provided formatter if available.  cebfbecc6f3c44cc0997fd61b1824f1d792d1c9b
