### PR TITLE
Make `moveRowAtIndexPath:toIndexPath:` public

### DIFF
--- a/XLForm/XL/Descriptors/XLFormSectionDescriptor.h
+++ b/XLForm/XL/Descriptors/XLFormSectionDescriptor.h
@@ -69,5 +69,6 @@ typedef NS_ENUM(NSUInteger, XLFormSectionInsertMode) {
 -(void)addFormRow:(nonnull XLFormRowDescriptor *)formRow beforeRow:(nonnull XLFormRowDescriptor *)beforeRow;
 -(void)removeFormRowAtIndex:(NSUInteger)index;
 -(void)removeFormRow:(nonnull XLFormRowDescriptor *)formRow;
+- (void)moveRowAtIndexPath:(NSIndexPath *)sourceIndex toIndexPath:(NSIndexPath *)destinationIndex;
 
 @end


### PR DESCRIPTION
Make `moveRowAtIndexPath:toIndexPath:` public in XLFormSectionDescriptor to allow to reorder rows programmatically.

Fixes #928 