### PR TITLE
Add formValuesIncludingHidden

### DIFF
--- a/XLForm/XL/Controllers/XLFormViewController.h
+++ b/XLForm/XL/Controllers/XLFormViewController.h
@@ -52,6 +52,7 @@ typedef NS_ENUM(NSUInteger, XLFormRowNavigationDirection) {
 -(XLFormBaseCell *)updateFormRow:(XLFormRowDescriptor *)formRow;
 
 -(NSDictionary *)formValues;
+-(NSDictionary *)formValuesIncludingHidden;
 -(NSDictionary *)httpParameters;
 
 -(XLFormRowDescriptor *)formRowFormMultivaluedFormSection:(XLFormSectionDescriptor *)formSection;

--- a/XLForm/XL/Controllers/XLFormViewController.m
+++ b/XLForm/XL/Controllers/XLFormViewController.m
@@ -346,6 +346,11 @@
     return [self.form formValues];
 }
 
+-(NSDictionary *)formValuesIncludingHidden
+{
+    return [self.form formValuesIncludingHidden];
+}
+
 -(NSDictionary *)httpParameters
 {
     return [self.form httpParameters:self];

--- a/XLForm/XL/Descriptors/XLFormDescriptor.h
+++ b/XLForm/XL/Descriptors/XLFormDescriptor.h
@@ -82,6 +82,7 @@ typedef NS_OPTIONS(NSUInteger, XLFormRowNavigationOptions) {
 -(nullable NSIndexPath *)indexPathOfFormRow:(nonnull XLFormRowDescriptor *)formRow;
 
 -(nonnull NSDictionary *)formValues;
+-(nonnull NSDictionary *)formValuesIncludingHidden;
 -(nonnull NSDictionary *)httpParameters:(nonnull XLFormViewController *)formViewController;
 
 -(nonnull NSArray *)localValidationErrors:(nonnull XLFormViewController *)formViewController;

--- a/XLForm/XL/Descriptors/XLFormDescriptor.m
+++ b/XLForm/XL/Descriptors/XLFormDescriptor.m
@@ -284,13 +284,25 @@ NSString * const XLValidationStatusErrorKey = @"XLValidationStatusErrorKey";
     return nil;
 }
 
+-(NSDictionary *)formValuesIncludingHidden
+{
+    return [self formValuesWithHidden:YES];
+}
+
 -(NSDictionary *)formValues
 {
-    NSMutableDictionary * result = [NSMutableDictionary dictionary];
-    for (XLFormSectionDescriptor * section in self.formSections) {
+    return [self formValuesWithHidden:NO];
+}
+
+-(NSDictionary *)formValuesWithHidden:(BOOL)includeHidden
+{
+    NSArray* sections = includeHidden ? self.allSections : self.formSections;
+    NSMutableDictionary* result = [NSMutableDictionary dictionary];
+    for (XLFormSectionDescriptor * section in sections) {
+        NSArray* rows = includeHidden ? section.allRows : section.formRows;
         if (section.multivaluedTag.length > 0){
-            NSMutableArray * multiValuedValuesArray = [NSMutableArray new];
-            for (XLFormRowDescriptor * row in section.formRows) {
+            NSMutableArray* multiValuedValuesArray = [NSMutableArray new];
+            for (XLFormRowDescriptor * row in rows) {
                 if (row.value){
                     [multiValuedValuesArray addObject:row.value];
                 }
@@ -298,7 +310,7 @@ NSString * const XLValidationStatusErrorKey = @"XLValidationStatusErrorKey";
             [result setObject:multiValuedValuesArray forKey:section.multivaluedTag];
         }
         else{
-            for (XLFormRowDescriptor * row in section.formRows) {
+            for (XLFormRowDescriptor * row in rows) {
                 if (row.tag.length > 0){
                     [result setObject:(row.value ?: [NSNull null]) forKey:row.tag];
                 }


### PR DESCRIPTION
This method returns all values of a form including the values of hidden rows.

Fixes #548 