### PR TITLE
Fixed setting value while searching

### DIFF
--- a/Examples/Objective-C/Examples/Selectors/DynamicSelector/UsersTableViewController.m
+++ b/Examples/Objective-C/Examples/Selectors/DynamicSelector/UsersTableViewController.m
@@ -205,15 +205,16 @@ static NSString *const kCellIdentifier = @"CellIdentifier";
 -(void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
     NSDictionary *dataItem = [self.dataStore dataAtIndexPath:indexPath];
-    
+
     self.rowDescriptor.value = dataItem;
     
-    if (self.popoverController){
+    if (self.popoverController) {
         [self.popoverController dismissPopoverAnimated:YES];
         [self.popoverController.delegate popoverControllerDidDismissPopover:self.popoverController];
-    }
-    else if ([self.parentViewController isKindOfClass:[UINavigationController class]]){
+    } else if ([self.parentViewController isKindOfClass:[UINavigationController class]]) {
         [self.navigationController popViewControllerAnimated:YES];
+    } else if ([self.presentingViewController isKindOfClass:[UsersTableViewController class]]) {
+        [[self.presentingViewController navigationController] popViewControllerAnimated:YES];
     }
 }
 
@@ -243,7 +244,9 @@ static NSString *const kCellIdentifier = @"CellIdentifier";
 -(UsersTableViewController *)searchResultController
 {
     if (_searchResultController) return _searchResultController;
-    _searchResultController = [[UsersTableViewController alloc]init];
+    UsersTableViewController *usersViewController = [[UsersTableViewController alloc] init];
+    usersViewController.rowDescriptor = self.rowDescriptor;
+    _searchResultController = usersViewController;
     _searchResultController.dataLoader.limit = 0; // no paging in search result
     _searchResultController.isSearchResultsController = YES;
     return _searchResultController;


### PR DESCRIPTION
Fixes #893.

When creating the `UsersTableViewController` is created it was missing pass the current value from `rowDescriptor`. Additionally, when a cell is selected from the search controller, it wasn't checking if `self` is actually presented.

![issue_893](https://cloud.githubusercontent.com/assets/4791678/26449988/954c8912-412b-11e7-8a22-3efadd32377a.gif)
