### PR TITLE
Fixed crash when trying to insert row in section at index 0

### DIFF
--- a/XLForm/XL/Descriptors/XLFormSectionDescriptor.m
+++ b/XLForm/XL/Descriptors/XLFormSectionDescriptor.m
@@ -125,7 +125,15 @@
 
 -(void)addFormRow:(XLFormRowDescriptor *)formRow
 {
-    [self insertObject:formRow inAllRowsAtIndex:([self canInsertUsingButton] ? MAX(0, [self.formRows count] - 1) : [self.allRows count])];
+    NSUInteger index;
+    
+    if ([self canInsertUsingButton]) {
+        index = ([self.formRows count] > 0) ? [self.formRows count] - 1 : 0;
+    } else {
+        index = [self.allRows count];
+    }
+
+    [self insertObject:formRow inAllRowsAtIndex:index];
 }
 
 -(void)addFormRow:(XLFormRowDescriptor *)formRow afterRow:(XLFormRowDescriptor *)afterRow


### PR DESCRIPTION
[self.formRows count] returns an NSUInteger (unsigned!)
If it returns 0, you cannot expect [self.formRows count] -1 to get
negative.
MAX(0, [self.formRows count] - 1) returns a high positive value instead.
Trying to insert a row at this invalid index throws an exception.