### PR TITLE
Fixes #900 - Cell disappears while inline date picker is open

### DIFF
--- a/XLForm/XL/Cell/XLFormDateCell.m
+++ b/XLForm/XL/Cell/XLFormDateCell.m
@@ -95,10 +95,10 @@
         NSIndexPath * selectedRowPath = [self.formViewController.form indexPathOfFormRow:self.rowDescriptor];
         NSIndexPath * nextRowPath = [NSIndexPath indexPathForRow:selectedRowPath.row + 1 inSection:selectedRowPath.section];
         XLFormRowDescriptor * nextFormRow = [self.formViewController.form formRowAtIndex:nextRowPath];
-        BOOL result = [super resignFirstResponder];
         if ([nextFormRow.rowType isEqualToString:XLFormRowDescriptorTypeDatePicker]){
             [self.rowDescriptor.sectionDescriptor removeFormRow:nextFormRow];
         }
+        BOOL result = [super resignFirstResponder];
         return result;
     }
     return [super resignFirstResponder];


### PR DESCRIPTION
Issue is caused by [super resignFirstResponder] call in subclass eventually making UIKit to call resignFirstResponder again. Changing the order of the call fixes the problem