### PR TITLE
Display the correct decimal separator for NSNumber according to locale

### DIFF
--- a/XLForm/XL/Descriptors/XLFormRowDescriptor.m
+++ b/XLForm/XL/Descriptors/XLFormRowDescriptor.m
@@ -27,6 +27,7 @@
 #import "XLFormViewController.h"
 #import "XLFormRowDescriptor.h"
 #import "NSString+XLFormAdditions.h"
+#import "NSNumber+XLFormAdditions.h"
 
 CGFloat XLFormUnspecifiedCellHeight = -3.0;
 CGFloat XLFormRowInitialHeight = -2;

--- a/XLForm/XL/Helpers/NSNumber+XLFormAdditions.h
+++ b/XLForm/XL/Helpers/NSNumber+XLFormAdditions.h
@@ -1,0 +1,14 @@
+//
+//  NSNumber+XLFormAdditions.m
+//  XLForm ( https://github.com/MatteoMilesi/XLForm )
+//
+//  Copyright (c) 2017 MatteoMilesi
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSNumber (XLFormAdditions)
+
+-(NSString *)displayText;
+
+@end

--- a/XLForm/XL/Helpers/NSNumber+XLFormAdditions.m
+++ b/XLForm/XL/Helpers/NSNumber+XLFormAdditions.m
@@ -1,0 +1,17 @@
+//
+//  NSNumber+XLFormAdditions.m
+//  XLForm ( https://github.com/MatteoMilesi/XLForm )
+//
+//  Copyright (c) 2017 MatteoMilesi
+//
+
+#import "NSNumber+XLFormAdditions.h"
+
+@implementation NSNumber (XLFormAdditions)
+
+-(NSString *)displayText
+{
+    return [NSString localizedStringWithFormat:@"%@", self];
+}
+
+@end


### PR DESCRIPTION
Fix for the problem described here by zinyakov: https://github.com/xmartlabs/XLForm/issues/452.
Now NSNumber(s) are displayed with the current locale format.