### PR TITLE
An option to use 3rd party (like a IQKeyboardManager) row navigation

### DIFF
--- a/XLForm/XL/Controllers/XLFormViewController.m
+++ b/XLForm/XL/Controllers/XLFormViewController.m
@@ -509,6 +509,9 @@
 
 - (void)keyboardWillShow:(NSNotification *)notification
 {
+    if (_form.rowNavigationOptions == XLFormRowNavigationOption3rdParty)
+        return;
+
     UIView * firstResponderView = [self.tableView findFirstResponder];
     UITableViewCell<XLFormDescriptorCell> * cell = [firstResponderView formDescriptorCell];
     if (cell){
@@ -535,6 +538,9 @@
 
 - (void)keyboardWillHide:(NSNotification *)notification
 {
+    if (_form.rowNavigationOptions == XLFormRowNavigationOption3rdParty)
+        return;
+
     UIView * firstResponderView = [self.tableView findFirstResponder];
     UITableViewCell<XLFormDescriptorCell> * cell = [firstResponderView formDescriptorCell];
     if (cell){

--- a/XLForm/XL/Descriptors/XLFormDescriptor.h
+++ b/XLForm/XL/Descriptors/XLFormDescriptor.h
@@ -43,6 +43,7 @@ typedef NS_OPTIONS(NSUInteger, XLFormRowNavigationOptions) {
     XLFormRowNavigationOptionStopDisableRow                     = 1 << 1,
     XLFormRowNavigationOptionSkipCanNotBecomeFirstResponderRow  = 1 << 2,
     XLFormRowNavigationOptionStopInlineRow                      = 1 << 3,
+    XLFormRowNavigationOption3rdParty                           = 1 << 4
 };
 
 @class XLFormSectionDescriptor;


### PR DESCRIPTION
XLForm doesn't behave well with IQKeyboardManager (scroll is broken after the keyboard is hidden). Same time, it has an issue with formatting back/forward buttons for iOS 10+ and left to right languages like Arabic and Hebrew. The proposed method is fastest one to implement, as an alternative more complex toolbar buttons handling could be implemented.