### PR TITLE
Fixes crash on update

### DIFF
--- a/XLForm/XL/Controllers/XLFormViewController.m
+++ b/XLForm/XL/Controllers/XLFormViewController.m
@@ -314,8 +314,8 @@
 
 -(void)updateAfterDependentRowChanged:(XLFormRowDescriptor *)formRow
 {
-    NSMutableArray* revaluateHidden   = self.form.rowObservers[[formRow.tag formKeyForPredicateType:XLPredicateTypeHidden]];
-    NSMutableArray* revaluateDisabled = self.form.rowObservers[[formRow.tag formKeyForPredicateType:XLPredicateTypeDisabled]];
+    NSMutableArray* revaluateHidden   = [self.form.rowObservers[[formRow.tag formKeyForPredicateType:XLPredicateTypeHidden]] copy];
+    NSMutableArray* revaluateDisabled = [self.form.rowObservers[[formRow.tag formKeyForPredicateType:XLPredicateTypeDisabled]] copy];
     for (id object in revaluateDisabled) {
         if ([object isKindOfClass:[NSString class]]) {
             XLFormRowDescriptor* row = [self.form formRowWithTag:object];


### PR DESCRIPTION
When `isHidden` or `isDisabled`of one `rowDescriptor` depends on another `rowDescriptor`, the contents of `revaluateHidden` and `revaluateDisabled` may change in the same time while executing`for` loops, which causes the crash.