### PR TITLE
Fix crash when using swift custom cells with xib files (#1038)

### DIFF
--- a/Examples/Swift/SwiftExample/AppDelegate.swift
+++ b/Examples/Swift/SwiftExample/AppDelegate.swift
@@ -17,9 +17,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         
         // Declare custom rows
-        XLFormViewController.cellClassesForRowDescriptorTypes()[XLFormRowDescriptorTypeRate] =  "XLFormRatingCell"
+        XLFormViewController.cellClassesForRowDescriptorTypes()[XLFormRowDescriptorTypeRate] =  NSStringFromClass(XLFormRatingCell.self)
         XLFormViewController.cellClassesForRowDescriptorTypes()[XLFormRowDescriptorTypeFloatLabeledTextField] = FloatLabeledTextFieldCell.self
-        XLFormViewController.cellClassesForRowDescriptorTypes()[XLFormRowDescriptorTypeWeekDays] = "XLFormWeekDaysCell"
+        XLFormViewController.cellClassesForRowDescriptorTypes()[XLFormRowDescriptorTypeWeekDays] = NSStringFromClass(XLFormWeekDaysCell.self)
         XLFormViewController.cellClassesForRowDescriptorTypes()[XLFormRowDescriptorTypeSegmentedInline] = InlineSegmentedCell.self
         XLFormViewController.cellClassesForRowDescriptorTypes()[XLFormRowDescriptorTypeSegmentedControl] = InlineSegmentedControl.self
         XLFormViewController.inlineRowDescriptorTypesForRowDescriptorTypes()[XLFormRowDescriptorTypeSegmentedInline] = XLFormRowDescriptorTypeSegmentedControl

--- a/XLForm/XL/Descriptors/XLFormRowDescriptor.m
+++ b/XLForm/XL/Descriptors/XLFormRowDescriptor.m
@@ -138,8 +138,6 @@ CGFloat XLFormRowInitialHeight = -2;
                 if ([cellClassString rangeOfString:@"."].location != NSNotFound) {
                     NSArray *components = [cellClassString componentsSeparatedByString:@"."];
                     cellResource = [components lastObject];
-                } else {
-                    cellResource = cellClassString;
                 }
             }
             NSParameterAssert(bundle != nil);

--- a/XLForm/XL/Descriptors/XLFormRowDescriptor.m
+++ b/XLForm/XL/Descriptors/XLFormRowDescriptor.m
@@ -135,6 +135,12 @@ CGFloat XLFormRowInitialHeight = -2;
             } else {
                 bundle = [NSBundle bundleForClass:NSClassFromString(cellClass)];
                 cellResource = cellClassString;
+                if ([cellClassString rangeOfString:@"."].location != NSNotFound) {
+                    NSArray *components = [cellClassString componentsSeparatedByString:@"."];
+                    cellResource = [components lastObject];
+                } else {
+                    cellResource = cellClassString;
+                }
             }
             NSParameterAssert(bundle != nil);
             NSParameterAssert(cellResource != nil);


### PR DESCRIPTION
Hi,

I've fixed a crash that occurs when using swift custom cells with xib files. (This is a known issue cf. #1038 ).

The NSClassFromString function does work for (pure and Objective-C-derived) swift classes, but only if you use the fully qualified name.

For example, in the module called SwiftExample with a pure swift class called XLFormRatingCell: 

`let XLFormRatingCellClass: AnyClass? = NSClassFromString("SwiftExample.XLFormRatingCell")`
or
`let XLFormRatingCellClass: AnyClass? = NSClassFromString(XLFormRatingCell.self)`
