### PR TITLE
Update XLFormRowDescriptor.m

### DIFF
--- a/XLForm/XL/Descriptors/XLFormRowDescriptor.m
+++ b/XLForm/XL/Descriptors/XLFormRowDescriptor.m
@@ -124,7 +124,7 @@ CGFloat XLFormRowInitialHeight = -2;
         
         NSBundle *bundle = [NSBundle mainBundle];
         NSString *cellClassString = cellClass;
-        NSString *cellResource = cellClassString;
+        NSString *cellResource = nil;
         
         NSAssert(cellClass, @"Not defined XLFormRowDescriptorType: %@", self.rowType ?: @"");
         
@@ -135,13 +135,12 @@ CGFloat XLFormRowInitialHeight = -2;
                 NSString *folderName = [components firstObject];
                 NSString *bundlePath = [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:folderName];
                 bundle = [NSBundle bundleWithPath:bundlePath];
+            } else {
+                cellResource = [cellClassString componentsSeparatedByString:@"."].lastObject;
             }
         } else {
-             cellResource = [NSStringFromClass(cellClass) componentsSeparatedByString:@"."].lastObject;
+            cellResource = [NSStringFromClass(cellClass) componentsSeparatedByString:@"."].lastObject;
         }
-        
-        NSParameterAssert(bundle != nil);
-        NSParameterAssert(cellResource != nil);
         
         if ([bundle pathForResource:cellResource ofType:@"nib"]) {
             _cell = [[bundle loadNibNamed:cellResource owner:nil options:nil] firstObject];

--- a/XLForm/XL/Descriptors/XLFormRowDescriptor.m
+++ b/XLForm/XL/Descriptors/XLFormRowDescriptor.m
@@ -119,40 +119,43 @@ CGFloat XLFormRowInitialHeight = -2;
 
 -(XLFormBaseCell *)cellForFormController:(XLFormViewController * __unused)formController
 {
-    if (!_cell){
+    if (!_cell) {
         id cellClass = self.cellClass ?: [XLFormViewController cellClassesForRowDescriptorTypes][self.rowType];
+        
+        NSBundle *bundle = [NSBundle mainBundle];
+        NSString *cellClassString = cellClass;
+        NSString *cellResource = cellClassString;
+        
         NSAssert(cellClass, @"Not defined XLFormRowDescriptorType: %@", self.rowType ?: @"");
+        
         if ([cellClass isKindOfClass:[NSString class]]) {
-            NSString *cellClassString = cellClass;
-            NSString *cellResource = nil;
-            NSBundle *bundle = nil;
             if ([cellClassString rangeOfString:@"/"].location != NSNotFound) {
                 NSArray *components = [cellClassString componentsSeparatedByString:@"/"];
                 cellResource = [components lastObject];
                 NSString *folderName = [components firstObject];
                 NSString *bundlePath = [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:folderName];
                 bundle = [NSBundle bundleWithPath:bundlePath];
-            } else {
-                bundle = [NSBundle bundleForClass:NSClassFromString(cellClass)];
-                cellResource = cellClassString;
-                if ([cellClassString rangeOfString:@"."].location != NSNotFound) {
-                    NSArray *components = [cellClassString componentsSeparatedByString:@"."];
-                    cellResource = [components lastObject];
-                }
             }
-            NSParameterAssert(bundle != nil);
-            NSParameterAssert(cellResource != nil);
-            
-            if ([bundle pathForResource:cellResource ofType:@"nib"]){
-                _cell = [[bundle loadNibNamed:cellResource owner:nil options:nil] firstObject];
-            }
+        } else {
+             cellResource = [NSStringFromClass(cellClass) componentsSeparatedByString:@"."].lastObject;
+        }
+        
+        NSParameterAssert(bundle != nil);
+        NSParameterAssert(cellResource != nil);
+        
+        if ([bundle pathForResource:cellResource ofType:@"nib"]) {
+            _cell = [[bundle loadNibNamed:cellResource owner:nil options:nil] firstObject];
         } else {
             _cell = [[cellClass alloc] initWithStyle:self.cellStyle reuseIdentifier:nil];
         }
+        
         _cell.rowDescriptor = self;
+        
         NSAssert([_cell isKindOfClass:[XLFormBaseCell class]], @"UITableViewCell must extend from XLFormBaseCell");
+        
         [self configureCellAtCreationTime];
     }
+    
     return _cell;
 }
 


### PR DESCRIPTION
@mats-claassen That's the correct fix for the issue I've opened a few weeks ago. This way custom cells with xib files can be declared using `<Class>.self` or `"<Class>"`. It's much cleaner than using `NSStringFromClass` as you've implemented in the other fix:

`XLFormViewController.cellClassesForRowDescriptorTypes()[XLFormRowDescriptorTypeRate] =  XLFormRatingCell.self`

or 

`XLFormViewController.cellClassesForRowDescriptorTypes()[XLFormRowDescriptorTypeRate] =  "XLFormRatingCell"`

I would revert the change done in https://github.com/xmartlabs/XLForm/commit/d8ece1410d76db3e95064e4d7a254a19134357b4 and use this one.