### PR TITLE
Fix crash when .Nib is inside a framework bundle.

### DIFF
--- a/XLForm/XL/Descriptors/XLFormRowDescriptor.m
+++ b/XLForm/XL/Descriptors/XLFormRowDescriptor.m
@@ -156,9 +156,9 @@ NSString * const XLHidePredicateCacheKey = @"hidePredicateCache";
         
         if ([bundle pathForResource:cellResource ofType:@"nib"]) {
             _cell = [[bundle loadNibNamed:cellResource owner:nil options:nil] firstObject];
-        }else if([bundleForCaller pathForResource:cellResource ofType:@"nib"]){
+        } else if ([bundleForCaller pathForResource:cellResource ofType:@"nib"]) {
             _cell = [[bundleForCaller loadNibNamed:cellResource owner:nil options:nil] firstObject];
-        }else {
+        } else {
             _cell = [[cellClass alloc] initWithStyle:self.cellStyle reuseIdentifier:nil];
         }
         

--- a/XLForm/XL/Descriptors/XLFormRowDescriptor.m
+++ b/XLForm/XL/Descriptors/XLFormRowDescriptor.m
@@ -136,6 +136,7 @@ NSString * const XLHidePredicateCacheKey = @"hidePredicateCache";
         NSBundle *bundle = [NSBundle mainBundle];
         NSString *cellClassString = cellClass;
         NSString *cellResource = nil;
+        NSBundle *bundleForCaller = [NSBundle bundleForClass:self.class];
         
         NSAssert(cellClass, @"Not defined XLFormRowDescriptorType: %@", self.rowType ?: @"");
         
@@ -155,7 +156,9 @@ NSString * const XLHidePredicateCacheKey = @"hidePredicateCache";
         
         if ([bundle pathForResource:cellResource ofType:@"nib"]) {
             _cell = [[bundle loadNibNamed:cellResource owner:nil options:nil] firstObject];
-        } else {
+        }else if([bundleForCaller pathForResource:cellResource ofType:@"nib"]){
+            _cell = [[bundleForCaller loadNibNamed:cellResource owner:nil options:nil] firstObject];
+        }else {
             _cell = [[cellClass alloc] initWithStyle:self.cellStyle reuseIdentifier:nil];
         }
         


### PR DESCRIPTION
I needed to wrap XLForm inside a private framework and implement custom cells. 
In this scenario a crash is obtained because the .nib file is not found inside the main bundle.
It is necessary to look for it within the private framework bundle.
This fix the issue.

